### PR TITLE
Configure newsletter form submission via Formspree

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Apri http://localhost:3000
 3) Framework: **Next.js** (auto). Build: `next build` (auto). Output: `.next` (auto).  
 4) Deploy.
 
+## Newsletter
+- Il modulo in `pages/newsletter.js` invia i dati a Formspree.
+- Imposta la variabile d'ambiente `NEXT_PUBLIC_FORMSPREE_NEWSLETTER_ID` con l'ID del tuo form Formspree (es. `abcd1234`).
+- In locale aggiungila a `.env.local`; su Vercel inseriscila nella sezione **Project → Settings → Environment Variables**.
+- Se la variabile manca il modulo resta disabilitato per evitare invii verso l'endpoint placeholder.
+
 ## Dominio personalizzato
 Aggiungi `attuario.eu` in **Project → Settings → Domains** e segui le istruzioni per i record DNS (A su 76.76.21.21 per l'apex; CNAME per www).
 

--- a/pages/newsletter.js
+++ b/pages/newsletter.js
@@ -1,0 +1,66 @@
+import Nav from "../components/Nav";
+import Footer from "../components/Footer";
+
+const formspreeId = process.env.NEXT_PUBLIC_FORMSPREE_NEWSLETTER_ID;
+const formAction = formspreeId ? `https://formspree.io/f/${formspreeId}` : undefined;
+
+export default function Newsletter(){
+  const isConfigured = Boolean(formAction);
+
+  return (
+    <>
+      <Nav/>
+      <main style={{maxWidth:720, margin:"0 auto", padding:"32px 16px"}}>
+        <h1 style={{fontSize:28, fontWeight:700}}>Newsletter</h1>
+        <p style={{opacity:.85}}>
+          Iscriviti per ricevere aggiornamenti su assicurazioni, attuariato e strumenti pratici per la gestione del rischio.
+        </p>
+        <form
+          action={formAction}
+          method="POST"
+          style={{display:"grid", gap:12, marginTop:16}}
+          onSubmit={isConfigured ? undefined : (event) => event.preventDefault()}
+        >
+          <label style={{display:"grid", gap:4}}>
+            <span style={{fontWeight:500}}>Email</span>
+            <input
+              name="email"
+              type="email"
+              placeholder="nome@azienda.it"
+              required
+              style={{padding:12, borderRadius:12, border:"1px solid #ddd"}}
+              disabled={!isConfigured}
+            />
+          </label>
+          <label style={{display:"grid", gap:4}}>
+            <span style={{fontWeight:500}}>Nome</span>
+            <input
+              name="nome"
+              placeholder="Il tuo nome"
+              style={{padding:12, borderRadius:12, border:"1px solid #ddd"}}
+              disabled={!isConfigured}
+            />
+          </label>
+          <button
+            type="submit"
+            style={{padding:"10px 16px", background:"#000", color:"#fff", borderRadius:999, width:"fit-content"}}
+            disabled={!isConfigured}
+          >
+            Iscriviti
+          </button>
+        </form>
+        {!isConfigured && (
+          <p style={{fontSize:12, opacity:.7, marginTop:12}}>
+            Configura la variabile d&apos;ambiente <code>NEXT_PUBLIC_FORMSPREE_NEWSLETTER_ID</code> per abilitare l&apos;invio del modulo.
+          </p>
+        )}
+        {isConfigured && (
+          <p style={{fontSize:12, opacity:.7, marginTop:8}}>
+            Con l’invio accetti <a href="/privacy">Privacy</a>.
+          </p>
+        )}
+      </main>
+      <Footer/>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a newsletter page that posts to Formspree using the `NEXT_PUBLIC_FORMSPREE_NEWSLETTER_ID` configuration
- disable the form when the ID is missing to avoid sending requests to a placeholder endpoint
- document the Formspree environment variable requirements in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9d2f3d4a4832d8ba8317d0f02fc37