### PR TITLE
Add AMP auto-ads integration for AdSense

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,23 +1,49 @@
-import { Html, Head, Main, NextScript } from "next/document";
+import Document, { Html, Head, Main, NextScript } from "next/document";
 
-export default function Document() {
-  return (
-    <Html lang="it">
-      <Head>
-        <meta
-          name="google-adsense-account"
-          content="ca-pub-8531177897035530"
-        />
-        <script
-          async
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8531177897035530"
-          crossOrigin="anonymous"
-        ></script>
-      </Head>
-      <body>
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  );
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    const isAmp = this.props.__NEXT_DATA__?.isAmp;
+
+    return (
+      <Html lang="it">
+        <Head>
+          <meta
+            name="google-adsense-account"
+            content="ca-pub-8531177897035530"
+          />
+          {!isAmp && (
+            <script
+              async
+              src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8531177897035530"
+              crossOrigin="anonymous"
+            ></script>
+          )}
+          {isAmp && (
+            <script
+              async
+              custom-element="amp-auto-ads"
+              src="https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js"
+            ></script>
+          )}
+        </Head>
+        <body>
+          {isAmp && (
+            <amp-auto-ads
+              type="adsense"
+              data-ad-client="ca-pub-8531177897035530"
+            ></amp-auto-ads>
+          )}
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }
+
+export default MyDocument;

--- a/pages/index.js
+++ b/pages/index.js
@@ -122,3 +122,5 @@ export default function Home() {
     </Layout>
   );
 }
+
+export const config = { amp: "hybrid" };


### PR DESCRIPTION
## Summary
- update the custom Document to detect AMP responses and only load the standard AdSense script for non-AMP pages
- inject the AMP auto-ads script and component when rendering AMP pages
- enable hybrid AMP mode for the home page so the AMP auto-ads markup is rendered server-side

## Testing
- not run (project prompts for ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68da70414cec832da1576b1ceac03a88