### PR TITLE
Add wiki link to navigation menu

### DIFF
--- a/components/Nav.js
+++ b/components/Nav.js
@@ -5,6 +5,7 @@ const links = [
   { href: "/applicazioni", label: "Applicazioni" },
   { href: "/attuario", label: "Attuari" },
   { href: "/risorse", label: "Risorse" },
+  { href: "/wiki", label: "Wiki" },
   { href: "/notizie", label: "Notizie" },
   { href: "/strumenti", label: "Strumenti" },
   { href: "/blog", label: "Blog" },


### PR DESCRIPTION
## Summary
- add a Wiki entry to the navigation links so knowledge resources are easier to find

## Testing
- ⚠️ `npm run lint` *(fails: command requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68da9fa974fc832d9c219bce17ba1f3c