### PR TITLE
Refactor static page content into shared modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Sito divulgativo per `attuario.eu` dedicato alla scienza attuariale con sezioni:
 
 ## Struttura del codice
 - `components/Layout.js` centralizza header, meta tag, navigazione e footer mantenendo il disclaimer divulgativo su ogni pagina.
+- Il menu principale usa i link dichiarati in `content/navigation.js`, così l'ordine di navigazione è configurabile senza toccare il componente.
+- I contenuti statici delle principali pagine editoriali sono raccolti in `content/pages/*.js`, rendendo più semplice aggiornare testi e liste senza scorrere JSX lungo.
 - Gli stili principali vivono in `styles/globals.css` con utility per griglie, card, bottoni e form coerenti fra le sezioni.
 
 ## Avvio locale

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -1,15 +1,6 @@
 import Link from "next/link";
 
-const links = [
-  { href: "/teoria", label: "Teoria" },
-  { href: "/applicazioni", label: "Applicazioni" },
-  { href: "/attuario", label: "Attuari" },
-  { href: "/risorse", label: "Risorse" },
-  { href: "/wiki", label: "Wiki" },
-  { href: "/notizie", label: "Notizie" },
-  { href: "/strumenti", label: "Strumenti" },
-  { href: "/blog", label: "Blog" },
-];
+import { NAV_LINKS } from "../content/navigation";
 
 export default function Nav() {
   return (
@@ -19,7 +10,7 @@ export default function Nav() {
           attuario.eu
         </Link>
         <nav className="site-nav" aria-label="Navigazione principale">
-          {links.map(({ href, label }) => (
+          {NAV_LINKS.map(({ href, label }) => (
             <Link key={href} href={href} className="site-nav__link">
               {label}
             </Link>

--- a/content/navigation.js
+++ b/content/navigation.js
@@ -1,0 +1,10 @@
+export const NAV_LINKS = [
+  { href: "/teoria", label: "Teoria" },
+  { href: "/applicazioni", label: "Applicazioni" },
+  { href: "/attuario", label: "Attuari" },
+  { href: "/risorse", label: "Risorse" },
+  { href: "/wiki", label: "Wiki" },
+  { href: "/notizie", label: "Notizie" },
+  { href: "/strumenti", label: "Strumenti" },
+  { href: "/blog", label: "Blog" },
+];

--- a/content/pages/applicazioni.js
+++ b/content/pages/applicazioni.js
@@ -1,0 +1,40 @@
+export const APPLICATION_AREAS = [
+  {
+    title: "Assicurazioni vita",
+    description:
+      "Pricing di polizze caso vita e caso morte, gestione delle partecipazioni agli utili e valutazione del longevity risk.",
+    bullet: [
+      "Esempi di tariffe per rendite e temporanee caso morte",
+      "Analisi della sensitività ai tassi di interesse",
+      "Check-list per documentazione Solvency II",
+    ],
+  },
+  {
+    title: "Assicurazioni danni e salute",
+    description: "Segmentazione portafogli auto, property e medical con GLM e metodi di credibilità.",
+    bullet: [
+      "Workflow per modelli frequenza × severità in R",
+      "Simulazioni di scenari catastrofali e stress test",
+      "Indicatori tecnici da monitorare nei report periodici",
+    ],
+  },
+  {
+    title: "Previdenza e fondi pensione",
+    description: "Valutazioni attuariali per TFR e fondi a capitalizzazione, analisi ALM e risk budgeting.",
+    bullet: [
+      "Esempio di calcolo delle passività IAS 19",
+      "Costruzione di scenari di contribuzione e rendimento",
+      "Checklist per le relazioni periodiche agli aderenti",
+    ],
+  },
+  {
+    title: "Finanza e risk management",
+    description:
+      "Metriche di rischio integrate per banche, assicurazioni e corporate, con focus su solvibilità e liquidità.",
+    bullet: [
+      "Modelli ORSA semplificati per PMI assicurative",
+      "Calcolo del capitale economico con metodi VaR e TVaR",
+      "KPI per la comunicazione ai comitati rischi",
+    ],
+  },
+];

--- a/content/pages/attuario.js
+++ b/content/pages/attuario.js
@@ -1,0 +1,46 @@
+export const ATTUARIO_ROLES = [
+  {
+    title: "Assicurazioni vita e danni",
+    description: "Dalla tariffazione alle riserve, gli attuari supportano le compagnie nel valutare prodotti e rischi.",
+    bullets: [
+      "Organizzazione tipica di un reparto attuariale",
+      "KPI di monitoraggio per ramo vita e danni",
+      "Skill richieste: modellistica, regolamentazione, comunicazione",
+    ],
+  },
+  {
+    title: "Previdenza e welfare",
+    description: "Gestione di fondi pensione e casse professionali con attenzione a sostenibilità e governance.",
+    bullets: [
+      "Ruoli chiave: attuario incaricato, risk manager, consulente del fondo",
+      "Come leggere una valutazione attuariale di TFR e piani a benefici definiti",
+      "Percorsi di carriera e certificazioni richieste in Italia",
+    ],
+  },
+  {
+    title: "Finanza, banche e risk management",
+    description: "Gli attuari portano competenze quantitative nei modelli interni, IFRS 17/9, gestione rischi e ALM.",
+    bullets: [
+      "Come interagire con funzioni CRO, CFO e audit interno",
+      "Esempi di progetti: ORSA, stress test, capital modelling",
+      "Strumenti analitici più usati: R, Python, SAS, SQL",
+    ],
+  },
+];
+
+export const ATTUARIO_PATHWAYS = [
+  {
+    title: "Percorsi formativi",
+    content:
+      "Panoramica su lauree magistrali in scienze attuariali, master specialistici, certificazioni SOA, CAS e Istituto Italiano degli Attuari.",
+  },
+  {
+    title: "Competenze trasversali",
+    content:
+      "Project management, data visualization, storytelling con dati e conoscenza dei framework normativi europei (Solvency II, IDD, PRIIPs).",
+  },
+  {
+    title: "Risorse per studenti",
+    content: "Guide agli esami, suggerimenti per tirocini, community online e programmi di mentoring.",
+  },
+];

--- a/content/pages/blog.js
+++ b/content/pages/blog.js
@@ -1,0 +1,27 @@
+export const BLOG_POSTS = [
+  {
+    title: "Stress test assicurativi: cosa impariamo dal report EIOPA 2023",
+    summary:
+      "Analisi dei principali indicatori di resilienza tratti dall’EIOPA Insurance Stress Test 2023 e implicazioni per le funzioni attuariali.",
+  },
+  {
+    title: "IFRS 17 in pratica: l’approccio GMM secondo l’IASB",
+    summary:
+      "Sintesi operativa basata sull’IFRS 17 Project Summary dell’IASB e sui recenti Transition Resource Group papers per impostare policy coerenti.",
+  },
+  {
+    title: "Risk Appetite Framework: le best practice IAIS per il board",
+    summary:
+      "Riepilogo delle Insurance Core Principles dell’IAIS e del paper sulla gestione integrata dei rischi per supportare decisioni consapevoli.",
+  },
+  {
+    title: "Climate risk e metriche ESG: insight dal network NGFS",
+    summary:
+      "Approccio divulgativo ai scenari climatici NGFS 2023 e alle raccomandazioni dell’UNEP FI per integrare KPI ESG nei modelli attuariali.",
+  },
+  {
+    title: "Pricing avanzato: lezioni dal report CAS sull’uso del machine learning",
+    summary:
+      "Panoramica delle linee guida CAS 2022 e dei white paper SOA per coniugare algoritmi complessi, interpretabilità e governance dei dati.",
+  },
+];

--- a/content/pages/home.js
+++ b/content/pages/home.js
@@ -1,0 +1,51 @@
+export const HOME_HIGHLIGHTS = [
+  {
+    title: "Teoria attuariale chiara",
+    text: "Formule spiegate con esempi numerici, grafici interattivi e mini-quiz per fissare i concetti chiave.",
+    link: "/teoria",
+  },
+  {
+    title: "Applicazioni pratiche",
+    text: "Dalla tariffazione vita e danni alla gestione delle riserve: casi studio e workflow replicabili.",
+    link: "/applicazioni",
+  },
+  {
+    title: "Risorse autorevoli",
+    text: "Raccolta curata di siti, blog e community attuariali per ispirarti e restare aggiornato.",
+    link: "/risorse",
+  },
+  {
+    title: "Strumenti e dataset",
+    text: "Tutorial su Excel, R e Python, template scaricabili e calcolatori online per esercitarsi.",
+    link: "/strumenti",
+  },
+  {
+    title: "Radar normativo",
+    text: "Aggiornamenti su Solvency II, IFRS 17 e ricerca accademica con sintesi divulgative.",
+    link: "/notizie",
+  },
+];
+
+export const HOME_PERSONAS = [
+  {
+    title: "Studente",
+    copy:
+      "Ripassa le basi matematiche, prova i calcolatori e consulta le guide sugli esami universitari e sulle certificazioni professionali.",
+  },
+  {
+    title: "Professionista",
+    copy:
+      "Approfondisci ALM, risk management e novità regolamentari con schede sintetiche e riferimenti alla letteratura di settore.",
+  },
+  {
+    title: "Curioso",
+    copy:
+      "Scopri come gli attuari analizzano rischi assicurativi e finanziari attraverso esempi concreti e articoli spiegati semplice.",
+  },
+];
+
+export const HOME_UPDATES = [
+  "Nuove schede su IFRS 17 e interazione con Solvency II nella sezione Notizie.",
+  "Script Python per simulare tavole di mortalità generazionali nella sezione Strumenti.",
+  "Serie “Attuario nel mondo reale”: focus su ruoli in previdenza complementare.",
+];

--- a/content/pages/notizie.js
+++ b/content/pages/notizie.js
@@ -1,0 +1,26 @@
+export const NEWS_UPDATES = [
+  {
+    title: "Regolamentazione",
+    entries: [
+      "Sintesi mensile delle novità su Solvency II, IDD e regolamenti IVASS.",
+      "Schede IFRS 17 con esempi di contabilizzazione semplificata.",
+      "Alert su consultazioni pubbliche europee e call for papers.",
+    ],
+  },
+  {
+    title: "Ricerca accademica",
+    entries: [
+      "Rassegna ASTIN Bulletin e European Actuarial Journal con highlight in italiano.",
+      "Working paper selezionati da SSRN e arXiv su rischio climatico e longevity.",
+      "Dataset aperti per esercitazioni (es. CAS Loss Reserving, Human Mortality Database).",
+    ],
+  },
+  {
+    title: "Eventi e community",
+    entries: [
+      "Calendario di seminari universitari, webinar professionali e conferenze attuariali.",
+      "Recap delle iniziative degli ordini professionali e associazioni studentesche.",
+      "Opportunità di call for speaker e progetti divulgativi collaborativi.",
+    ],
+  },
+];

--- a/content/pages/risorse.js
+++ b/content/pages/risorse.js
@@ -1,0 +1,65 @@
+export const RESOURCE_SECTIONS = [
+  {
+    title: "Istituzioni e formazione",
+    description: "Portali ufficiali e accademici da cui attingere documenti tecnici, normativa e percorsi di studio.",
+    items: [
+      {
+        name: "Ordine Nazionale degli Attuari",
+        url: "https://www.ordineattuari.it",
+        note: "Sezioni su chi è l'attuario, linee guida e documenti professionali.",
+      },
+      {
+        name: "Scuola di Attuariato",
+        url: "https://www.scuoladiattuariato.it",
+        note: "Calendario di corsi, aggiornamenti formativi e seminari italiani.",
+      },
+      {
+        name: "Institute and Faculty of Actuaries – Blog",
+        url: "https://blog.actuaries.org.uk",
+        note: "Approfondimenti professionali e riflessioni dei membri IFoA.",
+      },
+    ],
+  },
+  {
+    title: "Blog e magazine attuariali",
+    description: "Siti divulgativi e tecnici con articoli su carriera, modelli quantitativi e tendenze InsurTech.",
+    items: [
+      {
+        name: "ProActuary",
+        url: "https://www.proactuary.com",
+        note: "Guide su carriera, tecnologia attuariale e analisi delle competenze richieste.",
+      },
+      {
+        name: "Inspiring Actuaries",
+        url: "https://www.inspiringactuaries.com",
+        note: "Storie personali e consigli per studenti e professionisti emergenti.",
+      },
+      {
+        name: "The Actuarial Club",
+        url: "https://theactuarialclub.com",
+        note: "Tutorial pratici su reserving, GLM, esami e strumenti software.",
+      },
+    ],
+  },
+  {
+    title: "Community e risorse collaborative",
+    description: "Spazi per confrontarsi, reperire dataset e partecipare a progetti divulgativi.",
+    items: [
+      {
+        name: "Actuarial Outpost",
+        url: "https://www.actuarialoutpost.com",
+        note: "Forum internazionale per scambio di materiali, discussioni e supporto agli esami.",
+      },
+      {
+        name: "SSRN – Actuarial Science",
+        url: "https://www.ssrn.com/index.cfm/en/actuarial-science/",
+        note: "Working paper e ricerche emergenti su rischio, solvibilità e longevità.",
+      },
+      {
+        name: "Human Mortality Database",
+        url: "https://www.mortality.org",
+        note: "Dataset demografici open source per analisi di longevità e demografia.",
+      },
+    ],
+  },
+];

--- a/content/pages/servizi.js
+++ b/content/pages/servizi.js
@@ -1,0 +1,17 @@
+export const SERVICE_REDIRECTS = [
+  {
+    href: "/teoria",
+    title: "Studia la teoria",
+    text: "Lezioni, formule e quiz per consolidare le basi attuariali.",
+  },
+  {
+    href: "/strumenti",
+    title: "Usa gli strumenti",
+    text: "Template, notebook e calcolatori interattivi per esercitarti.",
+  },
+  {
+    href: "/contatti",
+    title: "Collabora con noi",
+    text: "Proponi articoli, eventi o iniziative divulgative.",
+  },
+];

--- a/content/pages/strumenti.js
+++ b/content/pages/strumenti.js
@@ -1,0 +1,26 @@
+export const TOOL_RESOURCES = [
+  {
+    title: "Excel e fogli di calcolo",
+    details: [
+      "Template per valore attuale di rendite e premi unici",
+      "Dashboard per analisi sinistri con pivot e grafici dinamici",
+      "Modelli di duration e immunizzazione con esempi passo-passo",
+    ],
+  },
+  {
+    title: "R e Python",
+    details: [
+      "Notebook su pacchetti lifecontingencies, actuar e ChainLadder",
+      "Esempi di simulazioni Monte Carlo per rischi demografici",
+      "Script per calcolare riserve con metodi stocastici",
+    ],
+  },
+  {
+    title: "Dataset e repository",
+    details: [
+      "Collezione curata di dataset pubblici: HMD, CAS Loss Reserving, Eurostat",
+      "Guide per pulizia dati e anonimizzazione",
+      "Suggerimenti per presentare insight a stakeholder non tecnici",
+    ],
+  },
+];

--- a/content/pages/teoria.js
+++ b/content/pages/teoria.js
@@ -1,0 +1,88 @@
+export const THEORY_TOPICS = [
+  {
+    title: "Matematica attuariale di base",
+    items: [
+      "Valore attuale atteso e criteri di equivalenza",
+      "Tavole di mortalità discrete e continue",
+      "Rendite temporanee, vitalizie e differite",
+    ],
+  },
+  {
+    title: "Modelli di sopravvivenza e rischio",
+    items: [
+      "Leggi di mortalità (Makeham, Gompertz)",
+      "Model point e costruzione di tavole generazionali",
+      "Probabilità congiunte e copule per rischi multipli",
+    ],
+  },
+  {
+    title: "Teoria delle assicurazioni",
+    items: [
+      "Premi puri, caricamenti e equilibrio tecnico",
+      "Metodi di credibilità classici e Bayesiani",
+      "Distribuzioni per sinistri danni e riassicurazione",
+    ],
+  },
+  {
+    title: "Riserve tecniche",
+    items: [
+      "Catene di Markov per sinistri vita",
+      "Triangoli (Chain Ladder, Bornhuetter-Ferguson)",
+      "Approccio stocastico con Bootstrap e Mack",
+    ],
+  },
+  {
+    title: "Finanza attuariale",
+    items: [
+      "Duration, convexity e immunizzazione",
+      "Asset Liability Management (ALM)",
+      "Gestione integrata del rischio con metriche VaR / TVaR",
+    ],
+  },
+];
+
+export const THEORY_RESEARCH_HIGHLIGHTS = [
+  {
+    title: "Principio di equivalenza attuariale",
+    description:
+      "Il premio è definito come valore attuale atteso dei flussi di prestazione, così da bilanciare incassi e pagamenti su base probabilistica. Il testo chiarisce come il tasso tecnico e le basi demografiche condizionano l'equilibrio contrattuale e la capitalizzazione dei premi.",
+  },
+  {
+    title: "Leggi di mortalità e intensità di rischio",
+    description:
+      "Le funzioni di sopravvivenza derivano dalla forza di mortalità µ_x(t) modellata, ad esempio, con le leggi di Gompertz o Makeham. La sintesi mostra come stimare i parametri da tavole di esperienza e come utilizzare i risultati nelle valutazioni attuariali di durata di vita residua.",
+  },
+  {
+    title: "Premi puri, caricamenti e credibilità",
+    description:
+      "Il premio puro nasce dal valore atteso del sinistro, mentre i caricamenti introducono margini per spese, rischio e utile. L'approfondimento descrive modelli individuali e collettivi, richiama il principio della varianza e illustra come i metodi di credibilità ponderano l'esperienza del portafoglio con le basi di riferimento.",
+  },
+  {
+    title: "Riserve prospettiche e retrospettive",
+    description:
+      "La riserva tecnica rappresenta il valore attuale delle prestazioni future al netto dei premi futuri e può essere calcolata in ottica prospettica o retrospettiva. La descrizione spiega la dinamica delle catene di pagamento, il ruolo delle assunzioni economiche e demografiche e l'impiego di modelli stocastici per stimare l'IBNR.",
+  },
+  {
+    title: "ALM e misure di rischio finanziario",
+    description:
+      "Duration e convexity sono utilizzate per immunizzare il portafoglio contro variazioni di tasso, coordinando attivi e passivi. L'approfondimento collega l'Asset Liability Management a metriche di rischio come VaR e TVaR, evidenziando l'uso di scenari deterministici e simulazioni stocastiche per la gestione del capitale.",
+  },
+  {
+    title: "📌 Micro-level stochastic loss reserving for general insurance",
+    description:
+      "Propone modelli granulari su singolo sinistro che combinano componenti di frequenza e severità con covariate assicurative, riducendo la dipendenza da assunzioni aggregate.",
+    slug: "/wiki/ricerche-attuariali.html#antonio-plat-2014",
+  },
+  {
+    title: "📊 The cost of financial frictions for life insurers",
+    description:
+      "Analizza come le restrizioni di capitale e le frizioni finanziarie influenzino prezzi, offerta di prodotti vita e allocazioni di portafoglio nel lungo periodo.",
+    slug: "/wiki/ricerche-attuariali.html#koijen-yogo-2016",
+  },
+  {
+    title: "🧮 On the calculation of the Solvency Capital Requirement based on nested simulations",
+    description:
+      "Approfondisce tecniche di simulazione annidata per il calcolo dello SCR, con focus su efficienza computazionale e accuratezza statistica.",
+    slug: "/wiki/ricerche-attuariali.html#bauer-reuss-singer-2012",
+  },
+];

--- a/docs/CONTENT_OVERVIEW.md
+++ b/docs/CONTENT_OVERVIEW.md
@@ -1,0 +1,33 @@
+# Mappa dei contenuti
+
+La cartella `content/` centralizza i testi statici usati dalle pagine Next.js per facilitare la manutenzione editoriale.
+
+## Navigazione
+
+- `content/navigation.js` esporta `NAV_LINKS`, l'elenco delle voci del menu principale.
+
+## Pagine
+
+Ogni file sotto `content/pages/` espone costanti tematiche richiamate dalla pagina omonima:
+
+- `applicazioni.js` → `APPLICATION_AREAS`
+- `attuario.js` → `ATTUARIO_ROLES`, `ATTUARIO_PATHWAYS`
+- `blog.js` → `BLOG_POSTS`
+- `home.js` → `HOME_HIGHLIGHTS`, `HOME_PERSONAS`, `HOME_UPDATES`
+- `notizie.js` → `NEWS_UPDATES`
+- `risorse.js` → `RESOURCE_SECTIONS`
+- `servizi.js` → `SERVICE_REDIRECTS`
+- `strumenti.js` → `TOOL_RESOURCES`
+- `teoria.js` → `THEORY_TOPICS`, `THEORY_RESEARCH_HIGHLIGHTS`
+
+La suddivisione rende più rapido:
+
+1. Aggiornare copy e link senza scrollare JSX lungo.
+2. Riutilizzare gli stessi blocchi in API o future pagine dinamiche.
+3. Aggiungere test (es. snapshot) sui contenuti editoriali.
+
+Per aggiungere una nuova sezione:
+
+1. Crea o aggiorna il file in `content/pages/` con le costanti esportate.
+2. Importa le costanti nella relativa pagina in `pages/`.
+3. Aggiorna eventuali componenti se il contenuto introduce nuove strutture.

--- a/pages/applicazioni.js
+++ b/pages/applicazioni.js
@@ -1,45 +1,6 @@
 import Layout from "../components/Layout";
 
-const areas = [
-  {
-    title: "Assicurazioni vita",
-    description:
-      "Pricing di polizze caso vita e caso morte, gestione delle partecipazioni agli utili e valutazione del longevity risk.",
-    bullet: [
-      "Esempi di tariffe per rendite e temporanee caso morte",
-      "Analisi della sensitività ai tassi di interesse",
-      "Check-list per documentazione Solvency II",
-    ],
-  },
-  {
-    title: "Assicurazioni danni e salute",
-    description: "Segmentazione portafogli auto, property e medical con GLM e metodi di credibilità.",
-    bullet: [
-      "Workflow per modelli frequenza × severità in R",
-      "Simulazioni di scenari catastrofali e stress test",
-      "Indicatori tecnici da monitorare nei report periodici",
-    ],
-  },
-  {
-    title: "Previdenza e fondi pensione",
-    description: "Valutazioni attuariali per TFR e fondi a capitalizzazione, analisi ALM e risk budgeting.",
-    bullet: [
-      "Esempio di calcolo delle passività IAS 19",
-      "Costruzione di scenari di contribuzione e rendimento",
-      "Checklist per le relazioni periodiche agli aderenti",
-    ],
-  },
-  {
-    title: "Finanza e risk management",
-    description:
-      "Metriche di rischio integrate per banche, assicurazioni e corporate, con focus su solvibilità e liquidità.",
-    bullet: [
-      "Modelli ORSA semplificati per PMI assicurative",
-      "Calcolo del capitale economico con metodi VaR e TVaR",
-      "KPI per la comunicazione ai comitati rischi",
-    ],
-  },
-];
+import { APPLICATION_AREAS } from "../content/pages/applicazioni";
 
 export default function Applicazioni() {
   return (
@@ -49,7 +10,7 @@ export default function Applicazioni() {
       intro="Come trasformare la teoria in decisioni operative. I moduli di questa sezione propongono workflow replicabili, dataset aperti e suggerimenti per presentazioni a stakeholder non tecnici."
     >
       <section className="card-grid">
-        {areas.map(({ title, description, bullet }) => (
+        {APPLICATION_AREAS.map(({ title, description, bullet }) => (
           <article key={title} className="card">
             <h2>{title}</h2>
             <p>{description}</p>

--- a/pages/attuario.js
+++ b/pages/attuario.js
@@ -1,51 +1,6 @@
 import Layout from "../components/Layout";
 
-const roles = [
-  {
-    title: "Assicurazioni vita e danni",
-    description: "Dalla tariffazione alle riserve, gli attuari supportano le compagnie nel valutare prodotti e rischi.",
-    bullets: [
-      "Organizzazione tipica di un reparto attuariale",
-      "KPI di monitoraggio per ramo vita e danni",
-      "Skill richieste: modellistica, regolamentazione, comunicazione",
-    ],
-  },
-  {
-    title: "Previdenza e welfare",
-    description: "Gestione di fondi pensione e casse professionali con attenzione a sostenibilità e governance.",
-    bullets: [
-      "Ruoli chiave: attuario incaricato, risk manager, consulente del fondo",
-      "Come leggere una valutazione attuariale di TFR e piani a benefici definiti",
-      "Percorsi di carriera e certificazioni richieste in Italia",
-    ],
-  },
-  {
-    title: "Finanza, banche e risk management",
-    description: "Gli attuari portano competenze quantitative nei modelli interni, IFRS 17/9, gestione rischi e ALM.",
-    bullets: [
-      "Come interagire con funzioni CRO, CFO e audit interno",
-      "Esempi di progetti: ORSA, stress test, capital modelling",
-      "Strumenti analitici più usati: R, Python, SAS, SQL",
-    ],
-  },
-];
-
-const pathways = [
-  {
-    title: "Percorsi formativi",
-    content:
-      "Panoramica su lauree magistrali in scienze attuariali, master specialistici, certificazioni SOA, CAS e Istituto Italiano degli Attuari.",
-  },
-  {
-    title: "Competenze trasversali",
-    content:
-      "Project management, data visualization, storytelling con dati e conoscenza dei framework normativi europei (Solvency II, IDD, PRIIPs).",
-  },
-  {
-    title: "Risorse per studenti",
-    content: "Guide agli esami, suggerimenti per tirocini, community online e programmi di mentoring.",
-  },
-];
+import { ATTUARIO_PATHWAYS, ATTUARIO_ROLES } from "../content/pages/attuario";
 
 export default function Attuario() {
   return (
@@ -55,7 +10,7 @@ export default function Attuario() {
       intro="Ruoli, responsabilità e percorsi professionali di chi applica la scienza attuariale ogni giorno. Interviste, testimonianze e materiali pubblici aiutano a comprendere come si evolvono le competenze richieste dal mercato."
     >
       <section className="card-grid">
-        {roles.map(({ title, description, bullets }) => (
+        {ATTUARIO_ROLES.map(({ title, description, bullets }) => (
           <article key={title} className="card">
             <h2>{title}</h2>
             <p>{description}</p>
@@ -71,7 +26,7 @@ export default function Attuario() {
       <section className="section">
         <h2>Percorsi e competenze</h2>
         <div className="card-grid">
-          {pathways.map(({ title, content }) => (
+          {ATTUARIO_PATHWAYS.map(({ title, content }) => (
             <div key={title} className="card">
               <h3>{title}</h3>
               <p>{content}</p>

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -1,32 +1,6 @@
 import Layout from "../components/Layout";
 
-const posts = [
-  {
-    title: "Stress test assicurativi: cosa impariamo dal report EIOPA 2023",
-    summary:
-      "Analisi dei principali indicatori di resilienza tratti dall’EIOPA Insurance Stress Test 2023 e implicazioni per le funzioni attuariali.",
-  },
-  {
-    title: "IFRS 17 in pratica: l’approccio GMM secondo l’IASB",
-    summary:
-      "Sintesi operativa basata sull’IFRS 17 Project Summary dell’IASB e sui recenti Transition Resource Group papers per impostare policy coerenti.",
-  },
-  {
-    title: "Risk Appetite Framework: le best practice IAIS per il board",
-    summary:
-      "Riepilogo delle Insurance Core Principles dell’IAIS e del paper sulla gestione integrata dei rischi per supportare decisioni consapevoli.",
-  },
-  {
-    title: "Climate risk e metriche ESG: insight dal network NGFS",
-    summary:
-      "Approccio divulgativo ai scenari climatici NGFS 2023 e alle raccomandazioni dell’UNEP FI per integrare KPI ESG nei modelli attuariali.",
-  },
-  {
-    title: "Pricing avanzato: lezioni dal report CAS sull’uso del machine learning",
-    summary:
-      "Panoramica delle linee guida CAS 2022 e dei white paper SOA per coniugare algoritmi complessi, interpretabilità e governance dei dati.",
-  },
-];
+import { BLOG_POSTS } from "../content/pages/blog";
 
 export default function Blog() {
   return (
@@ -36,7 +10,7 @@ export default function Blog() {
       intro="Articoli divulgativi, casi studio e rubriche mensili per avvicinare la scienza attuariale a un pubblico più ampio. Nessuna consulenza, solo condivisione di conoscenza."
     >
       <section className="card-grid">
-        {posts.map(({ title, summary }) => (
+        {BLOG_POSTS.map(({ title, summary }) => (
           <article key={title} className="card">
             <h2>{title}</h2>
             <p>{summary}</p>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,56 +1,10 @@
 import Layout from "../components/Layout";
 
-const highlights = [
-  {
-    title: "Teoria attuariale chiara",
-    text: "Formule spiegate con esempi numerici, grafici interattivi e mini-quiz per fissare i concetti chiave.",
-    link: "/teoria",
-  },
-  {
-    title: "Applicazioni pratiche",
-    text: "Dalla tariffazione vita e danni alla gestione delle riserve: casi studio e workflow replicabili.",
-    link: "/applicazioni",
-  },
-  {
-    title: "Risorse autorevoli",
-    text: "Raccolta curata di siti, blog e community attuariali per ispirarti e restare aggiornato.",
-    link: "/risorse",
-  },
-  {
-    title: "Strumenti e dataset",
-    text: "Tutorial su Excel, R e Python, template scaricabili e calcolatori online per esercitarsi.",
-    link: "/strumenti",
-  },
-  {
-    title: "Radar normativo",
-    text: "Aggiornamenti su Solvency II, IFRS 17 e ricerca accademica con sintesi divulgative.",
-    link: "/notizie",
-  },
-];
-
-const personas = [
-  {
-    title: "Studente",
-    copy:
-      "Ripassa le basi matematiche, prova i calcolatori e consulta le guide sugli esami universitari e sulle certificazioni professionali.",
-  },
-  {
-    title: "Professionista",
-    copy:
-      "Approfondisci ALM, risk management e novità regolamentari con schede sintetiche e riferimenti alla letteratura di settore.",
-  },
-  {
-    title: "Curioso",
-    copy:
-      "Scopri come gli attuari analizzano rischi assicurativi e finanziari attraverso esempi concreti e articoli spiegati semplice.",
-  },
-];
-
-const updates = [
-  "Nuove schede su IFRS 17 e interazione con Solvency II nella sezione Notizie.",
-  "Script Python per simulare tavole di mortalità generazionali nella sezione Strumenti.",
-  "Serie “Attuario nel mondo reale”: focus su ruoli in previdenza complementare.",
-];
+import {
+  HOME_HIGHLIGHTS,
+  HOME_PERSONAS,
+  HOME_UPDATES,
+} from "../content/pages/home";
 
 export default function Home() {
   return (
@@ -79,7 +33,7 @@ export default function Home() {
 
       <section id="sezioni" className="section">
         <div className="card-grid">
-          {highlights.map(({ title, text, link }) => (
+          {HOME_HIGHLIGHTS.map(({ title, text, link }) => (
             <a key={title} className="link-card" href={link}>
               <h3>{title}</h3>
               <p>{text}</p>
@@ -91,7 +45,7 @@ export default function Home() {
       <section className="section">
         <h2>Percorsi consigliati</h2>
         <div className="persona-grid">
-          {personas.map(({ title, copy }) => (
+          {HOME_PERSONAS.map(({ title, copy }) => (
             <div key={title} className="card">
               <h3>{title}</h3>
               <p>{copy}</p>
@@ -103,7 +57,7 @@ export default function Home() {
       <section className="section">
         <h2>Aggiornamenti recenti</h2>
         <ul className="list">
-          {updates.map((item) => (
+          {HOME_UPDATES.map((item) => (
             <li key={item}>{item}</li>
           ))}
         </ul>

--- a/pages/notizie.js
+++ b/pages/notizie.js
@@ -1,31 +1,6 @@
 import Layout from "../components/Layout";
 
-const updates = [
-  {
-    title: "Regolamentazione",
-    entries: [
-      "Sintesi mensile delle novità su Solvency II, IDD e regolamenti IVASS.",
-      "Schede IFRS 17 con esempi di contabilizzazione semplificata.",
-      "Alert su consultazioni pubbliche europee e call for papers.",
-    ],
-  },
-  {
-    title: "Ricerca accademica",
-    entries: [
-      "Rassegna ASTIN Bulletin e European Actuarial Journal con highlight in italiano.",
-      "Working paper selezionati da SSRN e arXiv su rischio climatico e longevity.",
-      "Dataset aperti per esercitazioni (es. CAS Loss Reserving, Human Mortality Database).",
-    ],
-  },
-  {
-    title: "Eventi e community",
-    entries: [
-      "Calendario di seminari universitari, webinar professionali e conferenze attuariali.",
-      "Recap delle iniziative degli ordini professionali e associazioni studentesche.",
-      "Opportunità di call for speaker e progetti divulgativi collaborativi.",
-    ],
-  },
-];
+import { NEWS_UPDATES } from "../content/pages/notizie";
 
 export default function Notizie() {
   return (
@@ -35,7 +10,7 @@ export default function Notizie() {
       intro="Un radar sulle principali novità normative e sulla ricerca attuariale internazionale. Ogni segnalazione include link alle fonti ufficiali e una spiegazione divulgativa."
     >
       <section className="card-grid">
-        {updates.map(({ title, entries }) => (
+        {NEWS_UPDATES.map(({ title, entries }) => (
           <article key={title} className="card">
             <h2>{title}</h2>
             <ul className="list">

--- a/pages/risorse.js
+++ b/pages/risorse.js
@@ -1,70 +1,6 @@
 import Layout from "../components/Layout";
 
-const sections = [
-  {
-    title: "Istituzioni e formazione",
-    description: "Portali ufficiali e accademici da cui attingere documenti tecnici, normativa e percorsi di studio.",
-    items: [
-      {
-        name: "Ordine Nazionale degli Attuari",
-        url: "https://www.ordineattuari.it",
-        note: "Sezioni su chi è l'attuario, linee guida e documenti professionali.",
-      },
-      {
-        name: "Scuola di Attuariato",
-        url: "https://www.scuoladiattuariato.it",
-        note: "Calendario di corsi, aggiornamenti formativi e seminari italiani.",
-      },
-      {
-        name: "Institute and Faculty of Actuaries – Blog",
-        url: "https://blog.actuaries.org.uk",
-        note: "Approfondimenti professionali e riflessioni dei membri IFoA.",
-      },
-    ],
-  },
-  {
-    title: "Blog e magazine attuariali",
-    description: "Siti divulgativi e tecnici con articoli su carriera, modelli quantitativi e tendenze InsurTech.",
-    items: [
-      {
-        name: "ProActuary",
-        url: "https://www.proactuary.com",
-        note: "Guide su carriera, tecnologia attuariale e analisi delle competenze richieste.",
-      },
-      {
-        name: "Inspiring Actuaries",
-        url: "https://www.inspiringactuaries.com",
-        note: "Storie personali e consigli per studenti e professionisti emergenti.",
-      },
-      {
-        name: "The Actuarial Club",
-        url: "https://theactuarialclub.com",
-        note: "Tutorial pratici su reserving, GLM, esami e strumenti software.",
-      },
-    ],
-  },
-  {
-    title: "Community e risorse collaborative",
-    description: "Spazi per confrontarsi, reperire dataset e partecipare a progetti divulgativi.",
-    items: [
-      {
-        name: "Actuarial Outpost",
-        url: "https://www.actuarialoutpost.com",
-        note: "Forum internazionale per scambio di materiali, discussioni e supporto agli esami.",
-      },
-      {
-        name: "SSRN – Actuarial Science",
-        url: "https://www.ssrn.com/index.cfm/en/actuarial-science/",
-        note: "Working paper e ricerche emergenti su rischio, solvibilità e longevità.",
-      },
-      {
-        name: "Human Mortality Database",
-        url: "https://www.mortality.org",
-        note: "Dataset demografici open source per analisi di longevità e demografia.",
-      },
-    ],
-  },
-];
+import { RESOURCE_SECTIONS } from "../content/pages/risorse";
 
 export default function Risorse() {
   return (
@@ -74,7 +10,7 @@ export default function Risorse() {
       intro="Una raccolta di portali, blog e community da esplorare per approfondire la professione attuariale. Ogni link rimanda a contenuti esterni affidabili: verifica sempre termini di utilizzo e diritti di autore."
     >
       <section className="card-grid">
-        {sections.map(({ title, description, items }) => (
+        {RESOURCE_SECTIONS.map(({ title, description, items }) => (
           <article key={title} className="card">
             <h2>{title}</h2>
             <p>{description}</p>

--- a/pages/servizi.js
+++ b/pages/servizi.js
@@ -1,22 +1,6 @@
 import Layout from "../components/Layout";
 
-const redirects = [
-  {
-    href: "/teoria",
-    title: "Studia la teoria",
-    text: "Lezioni, formule e quiz per consolidare le basi attuariali.",
-  },
-  {
-    href: "/strumenti",
-    title: "Usa gli strumenti",
-    text: "Template, notebook e calcolatori interattivi per esercitarti.",
-  },
-  {
-    href: "/contatti",
-    title: "Collabora con noi",
-    text: "Proponi articoli, eventi o iniziative divulgative.",
-  },
-];
+import { SERVICE_REDIRECTS } from "../content/pages/servizi";
 
 export default function Servizi() {
   return (
@@ -26,7 +10,7 @@ export default function Servizi() {
       intro="attuario.eu è un progetto divulgativo: non forniamo servizi professionali, preventivi o call commerciali. Il sito raccoglie risorse educative, strumenti open-source e aggiornamenti normativi per supportare studenti, docenti e operatori del settore."
     >
       <div className="card-grid">
-        {redirects.map(({ href, title, text }) => (
+        {SERVICE_REDIRECTS.map(({ href, title, text }) => (
           <a key={href} href={href} className="link-card">
             <h3>{title}</h3>
             <p>{text}</p>

--- a/pages/strumenti.js
+++ b/pages/strumenti.js
@@ -1,31 +1,6 @@
 import Layout from "../components/Layout";
 
-const resources = [
-  {
-    title: "Excel e fogli di calcolo",
-    details: [
-      "Template per valore attuale di rendite e premi unici",
-      "Dashboard per analisi sinistri con pivot e grafici dinamici",
-      "Modelli di duration e immunizzazione con esempi passo-passo",
-    ],
-  },
-  {
-    title: "R e Python",
-    details: [
-      "Notebook su pacchetti lifecontingencies, actuar e ChainLadder",
-      "Esempi di simulazioni Monte Carlo per rischi demografici",
-      "Script per calcolare riserve con metodi stocastici",
-    ],
-  },
-  {
-    title: "Dataset e repository",
-    details: [
-      "Collezione curata di dataset pubblici: HMD, CAS Loss Reserving, Eurostat",
-      "Guide per pulizia dati e anonimizzazione",
-      "Suggerimenti per presentare insight a stakeholder non tecnici",
-    ],
-  },
-];
+import { TOOL_RESOURCES } from "../content/pages/strumenti";
 
 export default function Strumenti() {
   return (
@@ -35,7 +10,7 @@ export default function Strumenti() {
       intro="Tutorial, esempi di codice e risorse aperte per esercitarsi con modelli attuariali. Gli strumenti sono pensati a fini educativi e non sostituiscono attività professionale."
     >
       <section className="card-grid">
-        {resources.map(({ title, details }) => (
+        {TOOL_RESOURCES.map(({ title, details }) => (
           <article key={title} className="card">
             <h2>{title}</h2>
             <ul className="list">

--- a/pages/teoria.js
+++ b/pages/teoria.js
@@ -1,94 +1,12 @@
 import Layout from "../components/Layout";
 
-const topics = [
-  {
-    title: "Matematica attuariale di base",
-    items: [
-      "Valore attuale atteso e criteri di equivalenza",
-      "Tavole di mortalità discrete e continue",
-      "Rendite temporanee, vitalizie e differite",
-    ],
-  },
-  {
-    title: "Modelli di sopravvivenza e rischio",
-    items: [
-      "Leggi di mortalità (Makeham, Gompertz)",
-      "Model point e costruzione di tavole generazionali",
-      "Probabilità congiunte e copule per rischi multipli",
-    ],
-  },
-  {
-    title: "Teoria delle assicurazioni",
-    items: [
-      "Premi puri, caricamenti e equilibrio tecnico",
-      "Metodi di credibilità classici e Bayesiani",
-      "Distribuzioni per sinistri danni e riassicurazione",
-    ],
-  },
-  {
-    title: "Riserve tecniche",
-    items: [
-      "Catene di Markov per sinistri vita",
-      "Triangoli (Chain Ladder, Bornhuetter-Ferguson)",
-      "Approccio stocastico con Bootstrap e Mack",
-    ],
-  },
-  {
-    title: "Finanza attuariale",
-    items: [
-      "Duration, convexity e immunizzazione",
-      "Asset Liability Management (ALM)",
-      "Gestione integrata del rischio con metriche VaR / TVaR",
-    ],
-  },
-];
+import {
+  THEORY_RESEARCH_HIGHLIGHTS,
+  THEORY_TOPICS,
+} from "../content/pages/teoria";
 
-const researchHighlights = [
-  {
-    title: "Principio di equivalenza attuariale",
-    description:
-      "Il premio è definito come valore attuale atteso dei flussi di prestazione, così da bilanciare incassi e pagamenti su base probabilistica. Il testo chiarisce come il tasso tecnico e le basi demografiche condizionano l'equilibrio contrattuale e la capitalizzazione dei premi.",
-  },
-  {
-    title: "Leggi di mortalità e intensità di rischio",
-    description:
-      "Le funzioni di sopravvivenza derivano dalla forza di mortalità µ_x(t) modellata, ad esempio, con le leggi di Gompertz o Makeham. La sintesi mostra come stimare i parametri da tavole di esperienza e come utilizzare i risultati nelle valutazioni attuariali di durata di vita residua.",
-  },
-  {
-    title: "Premi puri, caricamenti e credibilità",
-    description:
-      "Il premio puro nasce dal valore atteso del sinistro, mentre i caricamenti introducono margini per spese, rischio e utile. L'approfondimento descrive modelli individuali e collettivi, richiama il principio della varianza e illustra come i metodi di credibilità ponderano l'esperienza del portafoglio con le basi di riferimento.",
-  },
-  {
-    title: "Riserve prospettiche e retrospettive",
-    description:
-      "La riserva tecnica rappresenta il valore attuale delle prestazioni future al netto dei premi futuri e può essere calcolata in ottica prospettica o retrospettiva. La descrizione spiega la dinamica delle catene di pagamento, il ruolo delle assunzioni economiche e demografiche e l'impiego di modelli stocastici per stimare l'IBNR.",
-  },
-  {
-    title: "ALM e misure di rischio finanziario",
-    description:
-      "Duration e convexity sono utilizzate per immunizzare il portafoglio contro variazioni di tasso, coordinando attivi e passivi. L'approfondimento collega l'Asset Liability Management a metriche di rischio come VaR e TVaR, evidenziando l'uso di scenari deterministici e simulazioni stocastiche per la gestione del capitale.",
-  },
-  {
-    title: "📌 Micro-level stochastic loss reserving for general insurance",
-    description:
-      "Propone modelli granulari su singolo sinistro che combinano componenti di frequenza e severità con covariate assicurative, riducendo la dipendenza da assunzioni aggregate.",
-    slug: "/wiki/ricerche-attuariali.html#antonio-plat-2014",
-  },
-  {
-    title: "📊 The cost of financial frictions for life insurers",
-    description:
-      "Analizza come le restrizioni di capitale e le frizioni finanziarie influenzino prezzi, offerta di prodotti vita e allocazioni di portafoglio nel lungo periodo.",
-    slug: "/wiki/ricerche-attuariali.html#koijen-yogo-2016",
-  },
-  {
-    title:
-      "🧮 On the calculation of the Solvency Capital Requirement based on nested simulations",
-    description:
-      "Approfondisce tecniche di simulazione annidata per il calcolo dello SCR, con focus su efficienza computazionale e accuratezza statistica.",
-    slug: "/wiki/ricerche-attuariali.html#bauer-reuss-singer-2012",
-  },
-];
+const RESEARCH_CARDS = THEORY_RESEARCH_HIGHLIGHTS.filter((item) => !item.slug);
+const RESEARCH_LINKS = THEORY_RESEARCH_HIGHLIGHTS.filter((item) => item.slug);
 
 export default function Teoria() {
   return (
@@ -98,7 +16,7 @@ export default function Teoria() {
       intro="Una libreria digitale per consolidare le basi quantitative dell’attuario. Ogni modulo offre spiegazioni progressive, esempi numerici scaricabili e quiz auto-valutativi per monitorare il livello di comprensione."
     >
       <section className="card-grid">
-        {topics.map(({ title, items }) => (
+        {THEORY_TOPICS.map(({ title, items }) => (
           <article key={title} className="card">
             <h2>{title}</h2>
             <ul className="list">
@@ -113,14 +31,12 @@ export default function Teoria() {
       <section className="section">
         <h2>Quadri teorici fondamentali</h2>
         <div className="card-grid">
-          {researchHighlights
-            .filter((rh) => !rh.slug)
-            .map(({ title, description }) => (
-              <article key={title} className="card">
-                <h3>{title}</h3>
-                <p>{description}</p>
-              </article>
-            ))}
+          {RESEARCH_CARDS.map(({ title, description }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p>{description}</p>
+            </article>
+          ))}
         </div>
       </section>
 
@@ -140,25 +56,23 @@ export default function Teoria() {
 
       <section className="section info-panel">
         <h2>Ricerche consigliate</h2>
-        {researchHighlights
-          .filter((rh) => rh.slug)
-          .map(({ title, description, slug }) => (
-            <div
-              key={slug}
-              style={{
-                background: "#eef6ff",
-                padding: "1rem",
-                borderLeft: "4px solid #0066cc",
-                margin: "1rem 0",
-              }}
-            >
-              <h3>{title}</h3>
-              <p>{description}</p>
-              <a href={slug} target="_blank" rel="noopener noreferrer">
-                Apri la scheda completa
-              </a>
-            </div>
-          ))}
+        {RESEARCH_LINKS.map(({ title, description, slug }) => (
+          <div
+            key={slug}
+            style={{
+              background: "#eef6ff",
+              padding: "1rem",
+              borderLeft: "4px solid #0066cc",
+              margin: "1rem 0",
+            }}
+          >
+            <h3>{title}</h3>
+            <p>{description}</p>
+            <a href={slug} target="_blank" rel="noopener noreferrer">
+              Apri la scheda completa
+            </a>
+          </div>
+        ))}
       </section>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- move navigation links and all static page copy into the new `content/` directory for easier maintenance
- update pages and navigation components to read from the shared content modules and simplify JSX files
- document the new structure in the README and add `docs/CONTENT_OVERVIEW.md` to explain how content is organized

## Testing
- not run (Next.js lint setup prompts for configuration in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dab60125b4832da640fded939481ba