### PR TITLE
Amplia sezioni community e shop

### DIFF
--- a/pages/community.js
+++ b/pages/community.js
@@ -1,18 +1,150 @@
 import Layout from "../components/Layout";
 
+const COMMUNITY_CHANNELS = [
+  {
+    name: "Slack attuario.eu",
+    description:
+      "Canale principale per confrontarsi su esami, carriera e novità normative. Include thread dedicati a vita, danni, previdenza e data science.",
+    action: "Richiedi l'invito",
+    href: "/contatti",
+  },
+  {
+    name: "Forum Discourse",
+    description:
+      "Spazio asincrono per condividere case study, template di calcolo e discussioni approfondite su Solvency II e IFRS 17.",
+    action: "Entra nel forum",
+    href: "https://community.attuario.eu",
+  },
+  {
+    name: "Gruppi studio mensili",
+    description:
+      "Riunioni online di 60 minuti con focus tematici: preparazione esami professionali, approfondimenti su risk management e workshop di coding.",
+    action: "Prenota il prossimo slot",
+    href: "https://cal.attuario.eu/community",
+  },
+  {
+    name: "Newsletter collaboratori",
+    description:
+      "Aggiornamenti dietro le quinte con call for paper, idee editoriali e opportunità di mentorship tra membri senior e junior.",
+    action: "Iscriviti",
+    href: "/newsletter",
+  },
+];
+
+const COMMUNITY_INITIATIVES = [
+  {
+    title: "Office hour attuariale",
+    description:
+      "Sessioni Q&A live con professionisti che rispondono a dubbi su modelli, normativa e percorsi di carriera.",
+    cadence: "Ogni secondo martedì del mese",
+  },
+  {
+    title: "Co-writing di articoli",
+    description:
+      "Redazione condivisa di articoli divulgativi: dalla scelta delle fonti alla revisione peer-to-peer.",
+    cadence: "Timeline di 4 settimane per ogni ciclo editoriale",
+  },
+  {
+    title: "Hack lab dati",
+    description:
+      "Laboratorio collaborativo su dataset open source (HMD, CAS, Eurostat) per sperimentare tecniche di modellizzazione.",
+    cadence: "Ultimo giovedì del mese",
+  },
+];
+
+const COMMUNITY_GUIDELINES = [
+  "Adotta un linguaggio rispettoso e includi sempre le fonti delle statistiche o delle normative citate.",
+  "Evita di condividere dati sensibili o materiali coperti da copyright; privilegia dataset open source o sintetici.",
+  "Quando poni un quesito tecnico descrivi contesto, ipotesi e strumenti utilizzati per facilitare risposte utili.",
+  "Segnala ai moderatori comportamenti scorretti o violazioni della policy via canale #supporto-moderazione.",
+  "Non sono ammesse offerte commerciali o consulenze: l’obiettivo è la condivisione divulgativa e formativa.",
+];
+
+const COMMUNITY_SUPPORT = [
+  {
+    label: "Programma mentorship",
+    copy:
+      "Abbina studenti e giovani professionisti con mentor esperti su tematiche come pricing, riserve e risk management.",
+  },
+  {
+    label: "Calendario eventi",
+    copy:
+      "Google Calendar condiviso con webinar, call for paper, conferenze e deadline di certificazioni professionali.",
+  },
+  {
+    label: "Bacheca opportunità",
+    copy:
+      "Raccolta settimanale di stage, offerte di lavoro e progetti di ricerca aperti alla community.",
+  },
+];
+
 export default function Community() {
   return (
     <Layout
       title="Community"
       eyebrow="Spazio di confronto"
-      intro="Punto di raccolta per gruppi di studio, forum e iniziative collaborative. Personalizza questa sezione collegando la piattaforma community che preferisci (Discourse, Slack, Discord, ecc.)."
+      intro="Hub collaborativo per gruppi di studio, forum e iniziative tra professionisti, studenti e docenti. Qui trovi i canali ufficiali, il calendario delle attività e le linee guida per partecipare in modo efficace."
     >
-      <div className="info-panel">
+      <section className="info-panel" aria-labelledby="community-canali">
+        <h2 id="community-canali">Dove ci incontriamo</h2>
         <p>
-          Suggerimento: integra un feed Discourse o linka canali tematici (esami, carriera, normativa). Ricorda di indicare le
-          regole di partecipazione e la moderazione.
+          Scegli il canale più adatto al tuo stile di apprendimento: chat sincrone per confronto rapido, forum per discussioni approfondite, eventi live per esercitazioni e mentorship.
         </p>
-      </div>
+        <div className="card-grid">
+          {COMMUNITY_CHANNELS.map(({ name, description, action, href }) => (
+            <article key={name} className="card">
+              <h3>{name}</h3>
+              <p>{description}</p>
+              <a className="button secondary" href={href} target={href.startsWith("http") ? "_blank" : undefined} rel={href.startsWith("http") ? "noopener noreferrer" : undefined}>
+                {action}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section" aria-labelledby="community-iniziative">
+        <h2 id="community-iniziative">Attività ricorrenti</h2>
+        <div className="card-grid">
+          {COMMUNITY_INITIATIVES.map(({ title, description, cadence }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p>{description}</p>
+              <p className="small-print">{cadence}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" aria-labelledby="community-linee-guida">
+        <h2 id="community-linee-guida">Linee guida di partecipazione</h2>
+        <p>
+          La community è moderata da volontari: segui queste indicazioni per mantenere un ambiente accogliente e professionale.
+        </p>
+        <ul className="list">
+          {COMMUNITY_GUIDELINES.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+        <p className="small-print">
+          Ricorda che attuario.eu è un progetto divulgativo: nessuna consulenza o parere professionale, solo scambio di conoscenza.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="community-supporto">
+        <h2 id="community-supporto">Supporto e risorse dedicate</h2>
+        <div className="card-grid">
+          {COMMUNITY_SUPPORT.map(({ label, copy }) => (
+            <article key={label} className="card">
+              <h3>{label}</h3>
+              <p>{copy}</p>
+            </article>
+          ))}
+        </div>
+        <p className="small-print">
+          Vuoi proporre un nuovo gruppo o coordinare un workshop? Compila il form nella pagina <a href="/contatti">Contatti</a> specificando obiettivi, target e materiali proposti.
+        </p>
+      </section>
     </Layout>
   );
 }

--- a/pages/shop.js
+++ b/pages/shop.js
@@ -1,9 +1,129 @@
-export default function Page() {
+import Layout from "../components/Layout";
+
+const SHOP_BUNDLES = [
+  {
+    title: "Kit esami di matematica attuariale",
+    price: "€29",
+    description:
+      "Workbook interattivi, mappe concettuali e simulatori di quiz per preparare gli esami universitari e professionali.",
+    includes: [
+      "Notebook Jupyter con esercizi svolti in R e Python",
+      "Template Excel con formule commentate",
+      "Checklist di teoria con riferimenti bibliografici",
+      "Soluzioni passo-passo in PDF",
+    ],
+  },
+  {
+    title: "Pacchetto risk management",
+    price: "€39",
+    description:
+      "Dashboard, scenari ORSA e modelli per stress test pronti da personalizzare sulle esigenze della tua organizzazione.",
+    includes: [
+      "Modello ORSA semplificato con indicatori chiave",
+      "Template per reportistica verso CdA e funzione rischi",
+      "Script per simulazioni Monte Carlo su capitale economico",
+      "Linee guida per la documentazione del modello",
+    ],
+  },
+  {
+    title: "Toolkit data science attuariale",
+    price: "€34",
+    description:
+      "Pipeline di machine learning, esempi di feature engineering e notebook per analisi sinistri vita/danni.",
+    includes: [
+      "Script di data cleaning con controlli di qualità",
+      "Notebook GLM/GBM con interpretabilità e metriche",
+      "Template per documentare i dataset (Data Card)",
+      "Guida rapida a MLOps e monitoraggio drift",
+    ],
+  },
+];
+
+const SHOP_FAQ = [
+  {
+    question: "Come ricevo i materiali?",
+    answer:
+      "Dopo l'acquisto ricevi un link via email con accesso immediato ai file in formato ZIP. Gli aggiornamenti futuri vengono inviati automaticamente alla stessa casella.",
+  },
+  {
+    question: "Che licenza si applica?",
+    answer:
+      "Tutti i kit sono distribuiti con licenza personale. Puoi usarli per studio o formazione interna, ma non rivenderli o ripubblicarli online senza autorizzazione scritta.",
+  },
+  {
+    question: "Posso richiedere la fattura?",
+    answer:
+      "Sì. Una volta completato il checkout riceverai le istruzioni per inserire i dati di fatturazione e ottenere il documento fiscale conforme.",
+  },
+];
+
+const SHOP_STEPS = [
+  "Scegli il kit che ti interessa e aggiungilo al carrello.",
+  "Completa il pagamento sulla piattaforma partner (Stripe, Paddle o Lemon Squeezy).",
+  "Ricevi il link di download e accedi agli aggiornamenti futuri dal tuo account personale.",
+];
+
+export default function Shop() {
   return (
-    <div>
-      <h1>Shop</h1>
-      <div className="note">Template, script e tool attuariali pronti all’uso. Collega una piattaforma MoR (Paddle/Lemon Squeezy).</div>
-      <p>Personalizza questa pagina in <code>shop.js</code>.</p>
-    </div>
-  )
+    <Layout
+      title="Shop attuario.eu"
+      eyebrow="Kit digitali"
+      intro="Template, script e tool attuariali pronti all'uso. Questa pagina descrive le proposte editoriali e il flusso di acquisto: collega qui la tua piattaforma di e-commerce preferita per completare il checkout."
+    >
+      <section className="section" aria-labelledby="shop-bundle">
+        <h2 id="shop-bundle">Kit disponibili</h2>
+        <div className="card-grid">
+          {SHOP_BUNDLES.map(({ title, price, description, includes }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p className="small-print">{price} · download digitale</p>
+              <p>{description}</p>
+              <ul className="list">
+                {includes.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+              <a className="button secondary" href="/contatti">
+                Richiedi anteprima
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" aria-labelledby="shop-come-funziona">
+        <h2 id="shop-come-funziona">Come funziona il checkout</h2>
+        <ol className="list">
+          {SHOP_STEPS.map((step) => (
+            <li key={step}>{step}</li>
+          ))}
+        </ol>
+        <p className="small-print">
+          I pagamenti sono gestiti da provider esterni con conformità PSD2 e ricevute automatiche. attuario.eu non memorizza dati di carta di credito.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="shop-faq">
+        <h2 id="shop-faq">Domande frequenti</h2>
+        <div className="card-grid">
+          {SHOP_FAQ.map(({ question, answer }) => (
+            <article key={question} className="card">
+              <h3>{question}</h3>
+              <p>{answer}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" aria-labelledby="shop-supporto">
+        <h2 id="shop-supporto">Supporto e aggiornamenti</h2>
+        <p>
+          Ogni kit include una bacheca changelog e un canale dedicato nella community. Se hai suggerimenti o vuoi proporre un nuovo strumento scrivici da <a href="/contatti">Contatti</a> indicando obiettivi e requisiti funzionali.
+        </p>
+        <p className="small-print">
+          Tutti i materiali sono pensati per fini educativi e divulgativi. Non costituiscono consulenza professionale né sostituiscono le verifiche richieste da regolatori o auditor.
+        </p>
+      </section>
+    </Layout>
+  );
 }


### PR DESCRIPTION
## Summary
- arricchita la pagina Community con elenco dei canali ufficiali, calendario delle iniziative e linee guida di partecipazione
- trasformata la pagina Shop in un layout coerente con il resto del sito con kit digitali, flusso di checkout, FAQ e note di supporto

## Testing
- npm run lint *(interrotto: la procedura guidata richiede configurazione interattiva)*

------
https://chatgpt.com/codex/tasks/task_e_68dac5d2c77c832d93ed60287e37e8bd