### PR TITLE
Surface Community and Shop from home navigation

### DIFF
--- a/content/navigation.js
+++ b/content/navigation.js
@@ -3,8 +3,10 @@ export const NAV_LINKS = [
   { href: "/applicazioni", label: "Applicazioni" },
   { href: "/attuario", label: "Attuari" },
   { href: "/risorse", label: "Risorse" },
+  { href: "/community", label: "Community" },
   { href: "/wiki", label: "Wiki" },
   { href: "/notizie", label: "Notizie" },
   { href: "/strumenti", label: "Strumenti" },
+  { href: "/shop", label: "Shop" },
   { href: "/blog", label: "Blog" },
 ];

--- a/content/pages/home.js
+++ b/content/pages/home.js
@@ -5,9 +5,19 @@ export const HOME_HIGHLIGHTS = [
     link: "/teoria",
   },
   {
+    title: "Community attuario.eu",
+    text: "Partecipa alle discussioni su Discord, resta aggiornato via Telegram e unisciti a gruppi studio e mentorship tematici.",
+    link: "/community",
+  },
+  {
     title: "Applicazioni pratiche",
     text: "Dalla tariffazione vita e danni alla gestione delle riserve: workflow replicabili, dataset commentati e suggerimenti per presentare i risultati al management.",
     link: "/applicazioni",
+  },
+  {
+    title: "Shop attuario.eu",
+    text: "Kit digitali con template, script e guide operative per studiare, lavorare e formare team con materiali sempre aggiornati.",
+    link: "/shop",
   },
   {
     title: "Risorse autorevoli",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  amp: {
+    optimizer: false
+  }
 };
 export default nextConfig;

--- a/pages/community.js
+++ b/pages/community.js
@@ -1,18 +1,153 @@
 import Layout from "../components/Layout";
 
+const COMMUNITY_CHANNELS = [
+  {
+    name: "Server Discord",
+    description:
+      "Canale principale per confrontarsi in tempo reale su esami, carriera e novità normative. Include stanze vocali, canali tematici e bacheche per gruppi studio.",
+    action: "Accedi a Discord",
+    href: "https://discord.attuario.eu",
+  },
+  {
+    name: "Canale Telegram",
+    description:
+      "Aggiornamenti rapidi su eventi, uscite editoriali e call for paper. Perfetto se preferisci ricevere notifiche push senza perdere i thread principali.",
+    action: "Iscriviti su Telegram",
+    href: "https://t.me/attuarioeu",
+  },
+  {
+    name: "Gruppi studio mensili",
+    description:
+      "Riunioni online di 60 minuti con focus tematici: preparazione esami professionali, approfondimenti su risk management e workshop di coding.",
+    action: "Prenota il prossimo slot",
+    href: "https://cal.attuario.eu/community",
+  },
+  {
+    name: "Newsletter collaboratori",
+    description:
+      "Aggiornamenti dietro le quinte con call for paper, idee editoriali e opportunità di mentorship tra membri senior e junior.",
+    action: "Iscriviti",
+    href: "/newsletter",
+  },
+];
+
+const COMMUNITY_INITIATIVES = [
+  {
+    title: "Office hour attuariale",
+    description:
+      "Sessioni Q&A live con professionisti che rispondono a dubbi su modelli, normativa e percorsi di carriera.",
+    cadence: "Ogni secondo martedì del mese",
+  },
+  {
+    title: "Co-writing di articoli",
+    description:
+      "Redazione condivisa di articoli divulgativi: dalla scelta delle fonti alla revisione peer-to-peer.",
+    cadence: "Timeline di 4 settimane per ogni ciclo editoriale",
+  },
+  {
+    title: "Hack lab dati",
+    description:
+      "Laboratorio collaborativo su dataset open source (HMD, CAS, Eurostat) per sperimentare tecniche di modellizzazione.",
+    cadence: "Ultimo giovedì del mese",
+  },
+];
+
+const COMMUNITY_GUIDELINES = [
+  "Adotta un linguaggio rispettoso e includi sempre le fonti delle statistiche o delle normative citate.",
+  "Evita di condividere dati sensibili o materiali coperti da copyright; privilegia dataset open source o sintetici.",
+  "Quando poni un quesito tecnico descrivi contesto, ipotesi e strumenti utilizzati per facilitare risposte utili.",
+  "Segnala ai moderatori comportamenti scorretti o violazioni della policy via canale #supporto-moderazione.",
+  "Non sono ammesse offerte commerciali o consulenze: l’obiettivo è la condivisione divulgativa e formativa.",
+];
+
+const COMMUNITY_SUPPORT = [
+  {
+    label: "Programma mentorship",
+    copy:
+      "Abbina studenti e giovani professionisti con mentor esperti su tematiche come pricing, riserve e risk management.",
+  },
+  {
+    label: "Calendario eventi",
+    copy:
+      "Google Calendar condiviso con webinar, call for paper, conferenze e deadline di certificazioni professionali.",
+  },
+  {
+    label: "Bacheca opportunità",
+    copy:
+      "Raccolta settimanale di stage, offerte di lavoro e progetti di ricerca aperti alla community.",
+  },
+];
+
 export default function Community() {
   return (
     <Layout
       title="Community"
       eyebrow="Spazio di confronto"
-      intro="Punto di raccolta per gruppi di studio, forum e iniziative collaborative. Personalizza questa sezione collegando la piattaforma community che preferisci (Discourse, Slack, Discord, ecc.)."
+      intro="Hub collaborativo per gruppi di studio e iniziative tra professionisti, studenti e docenti. Qui trovi i canali ufficiali su Discord e Telegram, il calendario delle attività e le linee guida per partecipare in modo efficace."
     >
-      <div className="info-panel">
+      <section className="info-panel" aria-labelledby="community-canali">
+        <h2 id="community-canali">Dove ci incontriamo</h2>
         <p>
-          Suggerimento: integra un feed Discourse o linka canali tematici (esami, carriera, normativa). Ricorda di indicare le
-          regole di partecipazione e la moderazione.
+          Scegli il canale più adatto al tuo stile di apprendimento: chat e thread su Discord per confronto rapido e approfondito, aggiornamenti push su Telegram, eventi live per esercitazioni e mentorship.
         </p>
-      </div>
+        <p className="small-print">
+          Cerchi racconti e approfondimenti della community? Li trovi raccolti nel nostro <a href="/blog">blog</a>, insieme alle interviste e agli editoriali curati dal team.
+        </p>
+        <div className="card-grid">
+          {COMMUNITY_CHANNELS.map(({ name, description, action, href }) => (
+            <article key={name} className="card">
+              <h3>{name}</h3>
+              <p>{description}</p>
+              <a className="button secondary" href={href} target={href.startsWith("http") ? "_blank" : undefined} rel={href.startsWith("http") ? "noopener noreferrer" : undefined}>
+                {action}
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section" aria-labelledby="community-iniziative">
+        <h2 id="community-iniziative">Attività ricorrenti</h2>
+        <div className="card-grid">
+          {COMMUNITY_INITIATIVES.map(({ title, description, cadence }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p>{description}</p>
+              <p className="small-print">{cadence}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" aria-labelledby="community-linee-guida">
+        <h2 id="community-linee-guida">Linee guida di partecipazione</h2>
+        <p>
+          La community è moderata da volontari: segui queste indicazioni per mantenere un ambiente accogliente e professionale.
+        </p>
+        <ul className="list">
+          {COMMUNITY_GUIDELINES.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+        <p className="small-print">
+          Ricorda che attuario.eu è un progetto divulgativo: nessuna consulenza o parere professionale, solo scambio di conoscenza.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="community-supporto">
+        <h2 id="community-supporto">Supporto e risorse dedicate</h2>
+        <div className="card-grid">
+          {COMMUNITY_SUPPORT.map(({ label, copy }) => (
+            <article key={label} className="card">
+              <h3>{label}</h3>
+              <p>{copy}</p>
+            </article>
+          ))}
+        </div>
+        <p className="small-print">
+          Vuoi proporre un nuovo gruppo o coordinare un workshop? Compila il form nella pagina <a href="/contatti">Contatti</a> specificando obiettivi, target e materiali proposti.
+        </p>
+      </section>
     </Layout>
   );
 }

--- a/pages/community.js
+++ b/pages/community.js
@@ -94,7 +94,8 @@ export default function Community() {
         </p>
 
         <p className="small-print">
-          Cerchi racconti e approfondimenti della community? Li trovi raccolti nel nostro <a href="/blog">blog</a>, insieme alle interviste e agli editoriali curati dal team.
+          Cerchi racconti e approfondimenti della community? Li trovi raccolti nel nostro{" "}
+          <Link href="/blog">blog</Link>, insieme alle interviste e agli editoriali curati dal team.
         </p>
 
         <div className="card-grid">
@@ -149,9 +150,9 @@ export default function Community() {
           ))}
         </div>
         <p className="small-print">
-
-          Vuoi proporre un nuovo gruppo o coordinare un workshop? Compila il form nella pagina <a href="/contatti">Contatti</a> specificando obiettivi, target e materiali proposti.
-
+          Vuoi proporre un nuovo gruppo o coordinare un workshop? Compila il form nella pagina{" "}
+          <Link href="/contatti">Contatti</Link>{" "}
+          specificando obiettivi, target e materiali proposti.
         </p>
       </section>
     </Layout>

--- a/pages/index.js
+++ b/pages/index.js
@@ -28,6 +28,12 @@ export default function Home() {
           <a className="button secondary" href="#sezioni">
             Esplora le sezioni
           </a>
+          <a className="button secondary" href="/community">
+            Entra nella community
+          </a>
+          <a className="button secondary" href="/shop">
+            Scopri i kit digitali
+          </a>
         </div>
       </section>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -84,5 +84,3 @@ export default function Home() {
     </Layout>
   );
 }
-
-export const config = { amp: "hybrid" };

--- a/pages/index.js
+++ b/pages/index.js
@@ -30,12 +30,12 @@ export default function Home() {
           <a className="button secondary" href="#sezioni">
             Esplora le sezioni
           </a>
-          <a className="button secondary" href="/community">
+          <Link className="button secondary" href="/community">
             Entra nella community
-          </a>
-          <a className="button secondary" href="/shop">
+          </Link>
+          <Link className="button secondary" href="/shop">
             Scopri i kit digitali
-          </a>
+          </Link>
         </div>
       </section>
 

--- a/pages/shop.js
+++ b/pages/shop.js
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import Layout from "../components/Layout";
 
 const SHOP_BUNDLES = [
@@ -44,7 +46,7 @@ const SHOP_FAQ = [
     question: "Come ricevo i materiali?",
     answer:
 
-      "Dopo l'acquisto ricevi un link via email con accesso immediato ai file in formato ZIP. Gli aggiornamenti futuri vengono inviati automaticamente alla stessa casella.",
+      "Dopo l’acquisto ricevi un link via email con accesso immediato ai file in formato ZIP. Gli aggiornamenti futuri vengono inviati automaticamente alla stessa casella.",
   },
   {
     question: "Che licenza si applica?",
@@ -69,10 +71,10 @@ export default function Shop() {
     <Layout
       title="Shop attuario.eu"
       eyebrow="Kit digitali"
-      intro="Template, script e tool attuariali pronti all'uso. I kit sono pacchetti digitali scaricabili che combinano materiali pratici e aggiornamenti continui: qui trovi le proposte editoriali e il flusso di acquisto."
+      intro="Template, script e tool attuariali pronti all’uso. I kit sono pacchetti digitali scaricabili che combinano materiali pratici e aggiornamenti continui: qui trovi le proposte editoriali e il flusso di acquisto."
     >
       <section className="section info-panel" aria-labelledby="shop-definition">
-        <h2 id="shop-definition">Che cos'è un kit digitale</h2>
+        <h2 id="shop-definition">Che cos’è un kit digitale</h2>
         <p>
           Ogni kit raccoglie risorse coordinate su un tema attuariale: template modificabili, notebook con codice commentato, checklist operative e guide per applicare i contenuti in autonomia o in team.
         </p>
@@ -96,9 +98,9 @@ export default function Shop() {
                   <li key={item}>{item}</li>
                 ))}
               </ul>
-              <a className="button secondary" href="/contatti">
+              <Link className="button secondary" href="/contatti">
                 Richiedi anteprima
-              </a>
+              </Link>
 
             </article>
           ))}
@@ -132,8 +134,9 @@ export default function Shop() {
       <section className="section info-panel" aria-labelledby="shop-supporto">
         <h2 id="shop-supporto">Supporto e aggiornamenti</h2>
         <p>
-          Ogni kit include una bacheca changelog e un canale dedicato nella community. Se hai suggerimenti o vuoi proporre un nuovo strumento scrivici da <a href="/contatti">Contatti</a> indicando obiettivi e requisiti funzionali.
-
+          Ogni kit include una bacheca changelog e un canale dedicato nella community. Se hai suggerimenti o vuoi proporre un nuovo strumento scrivici da{" "}
+          <Link href="/contatti">Contatti</Link>{" "}
+          indicando obiettivi e requisiti funzionali.
         </p>
         <p className="small-print">
           Tutti i materiali sono pensati per fini educativi e divulgativi. Non costituiscono consulenza professionale né sostituiscono le verifiche richieste da regolatori o auditor.

--- a/pages/shop.js
+++ b/pages/shop.js
@@ -1,9 +1,141 @@
-export default function Page() {
+import Layout from "../components/Layout";
+
+const SHOP_BUNDLES = [
+  {
+    title: "Kit esami di matematica attuariale",
+    price: "€29",
+    description:
+      "Workbook interattivi, mappe concettuali e simulatori di quiz per preparare gli esami universitari e professionali.",
+    includes: [
+      "Notebook Jupyter con esercizi svolti in R e Python",
+      "Template Excel con formule commentate",
+      "Checklist di teoria con riferimenti bibliografici",
+      "Soluzioni passo-passo in PDF",
+    ],
+  },
+  {
+    title: "Pacchetto risk management",
+    price: "€39",
+    description:
+      "Dashboard, scenari ORSA e modelli per stress test pronti da personalizzare sulle esigenze della tua organizzazione.",
+    includes: [
+      "Modello ORSA semplificato con indicatori chiave",
+      "Template per reportistica verso CdA e funzione rischi",
+      "Script per simulazioni Monte Carlo su capitale economico",
+      "Linee guida per la documentazione del modello",
+    ],
+  },
+  {
+    title: "Toolkit data science attuariale",
+    price: "€34",
+    description:
+      "Pipeline di machine learning, esempi di feature engineering e notebook per analisi sinistri vita/danni.",
+    includes: [
+      "Script di data cleaning con controlli di qualità",
+      "Notebook GLM/GBM con interpretabilità e metriche",
+      "Template per documentare i dataset (Data Card)",
+      "Guida rapida a MLOps e monitoraggio drift",
+    ],
+  },
+];
+
+const SHOP_FAQ = [
+  {
+    question: "Come ricevo i materiali?",
+    answer:
+      "Dopo l'acquisto ricevi un link via email con accesso immediato ai file in formato ZIP. Gli aggiornamenti futuri vengono inviati automaticamente alla stessa casella.",
+  },
+  {
+    question: "Che licenza si applica?",
+    answer:
+      "Tutti i kit sono distribuiti con licenza personale. Puoi usarli per studio o formazione interna, ma non rivenderli o ripubblicarli online senza autorizzazione scritta.",
+  },
+  {
+    question: "Posso richiedere la fattura?",
+    answer:
+      "Sì. Una volta completato il checkout riceverai le istruzioni per inserire i dati di fatturazione e ottenere il documento fiscale conforme.",
+  },
+];
+
+const SHOP_STEPS = [
+  "Scegli il kit che ti interessa e aggiungilo al carrello.",
+  "Completa il pagamento sulla piattaforma partner (Stripe, Paddle o Lemon Squeezy).",
+  "Ricevi il link di download e accedi agli aggiornamenti futuri dal tuo account personale.",
+];
+
+export default function Shop() {
   return (
-    <div>
-      <h1>Shop</h1>
-      <div className="note">Template, script e tool attuariali pronti all’uso. Collega una piattaforma MoR (Paddle/Lemon Squeezy).</div>
-      <p>Personalizza questa pagina in <code>shop.js</code>.</p>
-    </div>
-  )
+    <Layout
+      title="Shop attuario.eu"
+      eyebrow="Kit digitali"
+      intro="Template, script e tool attuariali pronti all'uso. I kit sono pacchetti digitali scaricabili che combinano materiali pratici e aggiornamenti continui: qui trovi le proposte editoriali e il flusso di acquisto."
+    >
+      <section className="section info-panel" aria-labelledby="shop-definition">
+        <h2 id="shop-definition">Che cos'è un kit digitale</h2>
+        <p>
+          Ogni kit raccoglie risorse coordinate su un tema attuariale: template modificabili, notebook con codice commentato, checklist operative e guide per applicare i contenuti in autonomia o in team.
+        </p>
+        <ul className="list">
+          <li>Download immediato in formato ZIP con file organizzati per argomento.</li>
+          <li>Aggiornamenti gratuiti ogni volta che pubblichiamo nuove versioni o correzioni.</li>
+          <li>Accesso a un canale dedicato nella community per confrontarti con altri utilizzatori.</li>
+        </ul>
+      </section>
+
+      <section className="section" aria-labelledby="shop-bundle">
+        <h2 id="shop-bundle">Kit disponibili</h2>
+        <div className="card-grid">
+          {SHOP_BUNDLES.map(({ title, price, description, includes }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p className="small-print">{price} · download digitale</p>
+              <p>{description}</p>
+              <ul className="list">
+                {includes.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+              <a className="button secondary" href="/contatti">
+                Richiedi anteprima
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" aria-labelledby="shop-come-funziona">
+        <h2 id="shop-come-funziona">Come funziona il checkout</h2>
+        <ol className="list">
+          {SHOP_STEPS.map((step) => (
+            <li key={step}>{step}</li>
+          ))}
+        </ol>
+        <p className="small-print">
+          I pagamenti sono gestiti da provider esterni con conformità PSD2 e ricevute automatiche. attuario.eu non memorizza dati di carta di credito.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="shop-faq">
+        <h2 id="shop-faq">Domande frequenti</h2>
+        <div className="card-grid">
+          {SHOP_FAQ.map(({ question, answer }) => (
+            <article key={question} className="card">
+              <h3>{question}</h3>
+              <p>{answer}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" aria-labelledby="shop-supporto">
+        <h2 id="shop-supporto">Supporto e aggiornamenti</h2>
+        <p>
+          Ogni kit include una bacheca changelog e un canale dedicato nella community. Se hai suggerimenti o vuoi proporre un nuovo strumento scrivici da <a href="/contatti">Contatti</a> indicando obiettivi e requisiti funzionali.
+        </p>
+        <p className="small-print">
+          Tutti i materiali sono pensati per fini educativi e divulgativi. Non costituiscono consulenza professionale né sostituiscono le verifiche richieste da regolatori o auditor.
+        </p>
+      </section>
+    </Layout>
+  );
 }


### PR DESCRIPTION
## Summary
- add Community and Shop to the primary navigation so new sections are visible from the homepage
- extend the hero actions on the index to link directly to the community hub and digital kit shop
- reference the blog from the Community page to clarify where editorial updates live

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dac5d2c77c832d93ed60287e37e8bd