### PR TITLE
Add attuario.eu contact emails across pages

### DIFF
--- a/pages/community.js
+++ b/pages/community.js
@@ -152,7 +152,9 @@ export default function Community() {
         <p className="small-print">
           Vuoi proporre un nuovo gruppo o coordinare un workshop? Compila il form nella pagina{" "}
           <Link href="/contatti">Contatti</Link>{" "}
-          specificando obiettivi, target e materiali proposti.
+          specificando obiettivi, target e materiali proposti. In alternativa scrivi a{" "}
+          <a href="mailto:community@attuario.eu">community@attuario.eu</a>{" "}
+          per entrare in contatto con il team di moderazione.
         </p>
       </section>
     </Layout>

--- a/pages/contatti.js
+++ b/pages/contatti.js
@@ -24,6 +24,11 @@ export default function Contatti() {
         </button>
       </form>
       <p className="small-print">
+        Preferisci usare la tua casella di posta? Scrivici direttamente a{" "}
+        <a href="mailto:info@attuario.eu">info@attuario.eu</a>{" "}
+        per collaborazioni editoriali, idee per eventi e segnalazioni di risorse.
+      </p>
+      <p className="small-print">
         Con l’invio accetti la <Link href="/privacy">Privacy</Link>. I messaggi ricevuti vengono letti entro 72 ore.
       </p>
     </Layout>

--- a/pages/shop.js
+++ b/pages/shop.js
@@ -138,6 +138,10 @@ export default function Shop() {
           <Link href="/contatti">Contatti</Link>{" "}
           indicando obiettivi e requisiti funzionali.
         </p>
+        <p>
+          Per assistenza sugli acquisti o per ricevere fattura puoi anche contattarci via email a{" "}
+          <a href="mailto:shop@attuario.eu">shop@attuario.eu</a>.
+        </p>
         <p className="small-print">
           Tutti i materiali sono pensati per fini educativi e divulgativi. Non costituiscono consulenza professionale né sostituiscono le verifiche richieste da regolatori o auditor.
         </p>


### PR DESCRIPTION
## Summary
- add a direct info@attuario.eu mailto link on the contact page
- mention shop@attuario.eu for store support and community@attuario.eu for community moderation requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db18181d70832db40713cf1435e89d