### PR TITLE
Expand direct contact options on Contatti

### DIFF
--- a/pages/community.js
+++ b/pages/community.js
@@ -152,7 +152,9 @@ export default function Community() {
         <p className="small-print">
           Vuoi proporre un nuovo gruppo o coordinare un workshop? Compila il form nella pagina{" "}
           <Link href="/contatti">Contatti</Link>{" "}
-          specificando obiettivi, target e materiali proposti.
+          specificando obiettivi, target e materiali proposti. In alternativa scrivi a{" "}
+          <a href="mailto:community@attuario.eu">community@attuario.eu</a>{" "}
+          per entrare in contatto con il team di moderazione.
         </p>
       </section>
     </Layout>

--- a/pages/contatti.js
+++ b/pages/contatti.js
@@ -2,6 +2,21 @@ import Link from "next/link";
 
 import Layout from "../components/Layout";
 
+const CONTACT_METHODS = [
+  {
+    label: "Redazione e partnership",
+    email: "info@attuario.eu",
+  },
+  {
+    label: "Acquisti digital kit",
+    email: "shop@attuario.eu",
+  },
+  {
+    label: "Community e moderazione",
+    email: "community@attuario.eu",
+  },
+];
+
 export default function Contatti() {
   return (
     <Layout
@@ -10,19 +25,49 @@ export default function Contatti() {
       intro="attuario.eu non offre consulenza professionale o servizi commerciali. Puoi però proporre articoli, segnalare eventi, condividere dataset o suggerire risorse utili alla community."
       width="narrow"
     >
-      <form action="https://formspree.io/f/your-id" method="POST" className="form-grid">
-        <input className="input" name="nome" placeholder="Nome e affiliazione" required />
-        <input className="input" name="email" type="email" placeholder="Email" required />
-        <textarea
+      <form action="https://getform.io/f/akkpxgpa" method="POST" className="form-grid">
+        <input
           className="input"
-          name="messaggio"
-          placeholder="Descrivi la tua proposta o domanda"
+          type="text"
+          name="name"
+          placeholder="Nome e affiliazione"
+          autoComplete="name"
           required
         />
+        <input
+          className="input"
+          type="email"
+          name="email"
+          placeholder="Email"
+          autoComplete="email"
+          required
+        />
+        <textarea
+          className="input"
+          name="message"
+          placeholder="Descrivi la tua proposta o domanda"
+          rows={6}
+          required
+        />
+        <input type="hidden" name="_gotcha" aria-hidden="true" />
         <button className="button" type="submit">
           Invia
         </button>
       </form>
+      <section className="section info-panel" aria-labelledby="contatti-email">
+        <h2 id="contatti-email">Contatti diretti</h2>
+        <p className="small-print">
+          Preferisci scrivere dalla tua casella di posta? Usa l’indirizzo più adatto e riceverai risposta in 48 ore lavorative.
+        </p>
+        <ul className="list">
+          {CONTACT_METHODS.map(({ label, email }) => (
+            <li key={email}>
+              <span className="small-print">{label}:</span>{" "}
+              <a href={`mailto:${email}`}>{email}</a>
+            </li>
+          ))}
+        </ul>
+      </section>
       <p className="small-print">
         Con l’invio accetti la <Link href="/privacy">Privacy</Link>. I messaggi ricevuti vengono letti entro 72 ore.
       </p>

--- a/pages/shop.js
+++ b/pages/shop.js
@@ -138,6 +138,10 @@ export default function Shop() {
           <Link href="/contatti">Contatti</Link>{" "}
           indicando obiettivi e requisiti funzionali.
         </p>
+        <p>
+          Per assistenza sugli acquisti o per ricevere fattura puoi anche contattarci via email a{" "}
+          <a href="mailto:shop@attuario.eu">shop@attuario.eu</a>.
+        </p>
         <p className="small-print">
           Tutti i materiali sono pensati per fini educativi e divulgativi. Non costituiscono consulenza professionale né sostituiscono le verifiche richieste da regolatori o auditor.
         </p>


### PR DESCRIPTION
## Summary
- list dedicated attuario.eu email indirizzi for redazione, shop e community direttamente nella pagina Contatti
- mantenere il form Getform minimale con soli campi essenziali e honeypot anti-spam
- aggiungere una sezione informativa sui tempi di risposta e sui contatti diretti

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68db18181d70832db40713cf1435e89d