### PR TITLE
Improve contact form reliability and document community status

### DIFF
--- a/docs/COMMUNITY_STATUS.md
+++ b/docs/COMMUNITY_STATUS.md
@@ -1,0 +1,19 @@
+# Stato delle integrazioni community
+
+## Client Telegram CLI (`vysheng/tg`)
+- Il repository open source `vysheng/tg` è ancora disponibile su GitHub ma non riceve commit dal 23 marzo 2016 (`6547c0b21b977b327b3c5e8142963f4bc246187a`). Questo significa che funziona solo su distribuzioni Linux con librerie compatibili (OpenSSL < 1.1 per build native) e richiede patch manuali per versioni moderne.
+- Per un utilizzo stabile conviene compilare il progetto in un container Debian/Ubuntu LTS, installare le dipendenze `libreadline-dev`, `libconfig-dev`, `libssl-dev`, `libevent-dev` e sostituire `openssl` con `libssl1.0-dev` dove necessario. In alternativa si può ricorrere ai bot ufficiali o al client Telegram Desktop.
+- Se si decide di usare `tg`, predisporre un wrapper che aggiorni automaticamente il file `~/.telegram-cli/state` per evitare errori di login e documentare il flusso di autenticazione a due fattori.
+
+## Form contatti (Getform)
+- Il form ora invia i dati a un endpoint interno (`/api/contact`) che effettua la validazione dei campi e inoltra la richiesta al form endpoint Getform. In caso di errore la pagina mostra un messaggio contestuale e suggerisce di riprovare o usare l'email diretta.
+- L'API server-side restituisce codici espliciti per errori di validazione (400) e per problemi di rete/upstream (502) così da poter registrare i casi critici su Vercel (tramite log) o strumenti di osservabilità.
+
+## Stato canali community
+- Il server Discord pubblico è stato messo in manutenzione mentre si revisionano automazioni e linee guida. La pagina community indirizza ora gli utenti verso la lista di attesa via email.
+- Il canale Telegram resta attivo come canale principale per gli aggiornamenti. Nella pagina community sono riportate anche indicazioni per utilizzare client alternativi (es. `tg`) specificando che il progetto non è più mantenuto.
+
+## Raccomandazioni operative
+- Monitorare periodicamente le consegne Getform dalle dashboard per verificare che gli inoltri generati dall'API siano recapitati (log HTTP 200) e che non ci siano blocchi anti-spam.
+- Valutare, appena pronti i nuovi workflow di moderazione, se ripristinare il link diretto a Discord oppure sostituirlo con un form di candidatura per i moderatori.
+- Documentare nella knowledge base interna l'uso di client CLI deprecati (come `tg`) per evitare richieste di supporto su canali non ufficiali.

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -1,0 +1,74 @@
+const GETFORM_ENDPOINT = "https://getform.io/f/akkpxgpa";
+
+function validateEmail(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+  return /.+@.+\..+/.test(value.trim());
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).json({ message: "Metodo non consentito" });
+  }
+
+  const { name, email, message, _gotcha = "", ...rest } = req.body ?? {};
+
+  if (!name || !email || !message) {
+    return res
+      .status(400)
+      .json({
+        message:
+          "Compila tutti i campi obbligatori (nome, email e messaggio) prima di inviare.",
+      });
+  }
+
+  if (!validateEmail(email)) {
+    return res.status(400).json({ message: "Indirizzo email non valido." });
+  }
+
+  const payload = new URLSearchParams();
+  payload.append("name", name);
+  payload.append("email", email);
+  payload.append("message", message);
+  payload.append("_gotcha", _gotcha);
+
+  Object.entries(rest).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== "") {
+      if (Array.isArray(value)) {
+        value.forEach((item) => payload.append(key, item));
+      } else {
+        payload.append(key, String(value));
+      }
+    }
+  });
+
+  try {
+    const response = await fetch(GETFORM_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: payload.toString(),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text();
+      return res.status(502).json({
+        message:
+          "Impossibile inoltrare il messaggio a Getform. Riprova più tardi o contattaci via email.",
+        detail,
+      });
+    }
+
+    return res.status(200).json({ message: "Messaggio inviato correttamente." });
+  } catch (error) {
+    return res.status(502).json({
+      message:
+        "Si è verificato un errore di rete durante l'inoltro del messaggio.",
+      detail: error.message,
+    });
+  }
+}

--- a/pages/community.js
+++ b/pages/community.js
@@ -4,16 +4,16 @@ import Layout from "../components/Layout";
 
 const COMMUNITY_CHANNELS = [
   {
-    name: "Server Discord",
+    name: "Server Discord (in manutenzione)",
     description:
-      "Canale principale per confrontarsi in tempo reale su esami, carriera e novità normative. Include stanze vocali, canali tematici e bacheche per gruppi studio.",
-    action: "Accedi a Discord",
-    href: "https://discord.attuario.eu",
+      "Il server pubblico è temporaneamente offline mentre rivediamo moderazione e automazioni. Iscriviti alla lista di attesa per ricevere l'invito non appena riapre.",
+    action: "Richiedi aggiornamenti",
+    href: "mailto:community@attuario.eu?subject=Aggiornamenti%20Discord",
   },
   {
     name: "Canale Telegram",
     description:
-      "Aggiornamenti rapidi su eventi, uscite editoriali e call for paper. Perfetto se preferisci ricevere notifiche push senza perdere i thread principali.",
+      "Aggiornamenti rapidi su eventi, uscite editoriali e call for paper. Puoi seguirci dall'app ufficiale oppure da client CLI come tg (Linux), tenendo conto che il progetto open source non è più attivamente mantenuto.",
     action: "Iscriviti su Telegram",
     href: "https://t.me/attuarioeu",
   },


### PR DESCRIPTION
## Summary
- add a server-side contact API that validates submissions and forwards them to Getform
- update the contact page UI to surface submission status messages via the new endpoint
- mark the Discord channel as under maintenance and document the status of community integrations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db2556dd88832db860fa3da0250e82