### PR TITLE
Improve case study navigation and metadata

### DIFF
--- a/components/casi/CaseNavigation.js
+++ b/components/casi/CaseNavigation.js
@@ -1,0 +1,58 @@
+import Link from "next/link";
+
+import { CASE_STUDIES } from "../../content/pages/casi";
+
+function buildRelatedCases(currentSlug, relatedSlugs = []) {
+  if (relatedSlugs.length === 0) {
+    return CASE_STUDIES.filter(({ slug }) => slug !== currentSlug).slice(0, 3);
+  }
+
+  return relatedSlugs
+    .map((slug) => CASE_STUDIES.find((caseStudy) => caseStudy.slug === slug))
+    .filter(Boolean);
+}
+
+export default function CaseNavigation({ currentSlug, relatedSlugs }) {
+  const relatedCases = buildRelatedCases(currentSlug, relatedSlugs);
+
+  return (
+    <section className="section info-panel" aria-labelledby="case-nav-heading">
+      <h2 id="case-nav-heading">Continua con altri case study</h2>
+      <p>
+        Approfondisci percorsi affini oppure torna all’elenco completo per scegliere un nuovo scenario operativo da
+        esplorare.
+      </p>
+      <div className="case-nav__links">
+        {relatedCases.map(({ slug, title, summary }) => (
+          <Link key={slug} className="link-card" href={`/casi/${slug}`}>
+            <h3>{title}</h3>
+            <p>{summary}</p>
+          </Link>
+        ))}
+      </div>
+      <div className="case-nav__cta">
+        <Link className="button" href="/casi">
+          Torna all’elenco completo
+        </Link>
+        <Link className="button secondary" href="/applicazioni">
+          Rivedi le Applicazioni
+        </Link>
+      </div>
+
+      <style jsx>{`
+        .case-nav__links {
+          display: grid;
+          gap: 16px;
+          grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+          margin: 24px 0;
+        }
+
+        .case-nav__cta {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 12px;
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/content/navigation.js
+++ b/content/navigation.js
@@ -2,6 +2,7 @@ export const NAV_LINKS = [
   { href: "/corso", label: "Corso" },
   { href: "/teoria", label: "Teoria" },
   { href: "/applicazioni", label: "Applicazioni" },
+  { href: "/casi", label: "Case study" },
   { href: "/attuario", label: "Attuari" },
   { href: "/risorse", label: "Risorse" },
   { href: "/community", label: "Community" },

--- a/content/pages/applicazioni.js
+++ b/content/pages/applicazioni.js
@@ -8,7 +8,7 @@ export const APPLICATION_AREAS = [
         label: "Tariffazione temporanee caso morte",
         summary:
           "Usa il template valore attuale per stimare premi puri e confronta l’impatto delle basi demografiche IPS55 vs proiezioni generazionali.",
-        href: "/casi/assicurazioni-vita.html",
+        href: "/casi/assicurazioni-vita",
       },
       {
         label: "Sensitività tassi d’interesse",
@@ -20,7 +20,7 @@ export const APPLICATION_AREAS = [
         label: "Checklist POG & documentazione",
         summary:
           "Scarica la scheda con requisiti IDD/POG e integra il memorandum regolamentare nel fascicolo di prodotto.",
-        href: "/casi/assicurazioni-vita.html#output-attesi",
+        href: "/casi/assicurazioni-vita#output-attesi",
       },
     ],
   },
@@ -33,19 +33,19 @@ export const APPLICATION_AREAS = [
         label: "Workflow frequenza × severità",
         summary:
           "Implementa un modello GLM in R seguendo lo script di riferimento e genera mappe di rischio per la direzione tecnica.",
-        href: "/casi/assicurazioni-danni.html",
+        href: "/casi/assicurazioni-danni",
       },
       {
         label: "Stress test catastrofali",
         summary:
           "Applica scenari vento 1/100 agli exposure property per definire strategie riassicurative e capitali addizionali.",
-        href: "/casi/assicurazioni-danni.html#output-attesi",
+        href: "/casi/assicurazioni-danni#output-attesi",
       },
       {
         label: "Telematica e pricing dinamico",
         summary:
           "Integra variabili telematiche in un modello usage-based e costruisci offerte personalizzate con soglie di rischio.",
-        href: "/casi/data-science.html",
+        href: "/casi/data-science",
       },
     ],
   },
@@ -58,19 +58,19 @@ export const APPLICATION_AREAS = [
         label: "IAS 19 e passività attuariali",
         summary:
           "Calcola obbligazioni attuariali a benefici definiti e documenta le assunzioni economiche per la nota integrativa.",
-        href: "/casi/previdenza.html",
+        href: "/casi/previdenza",
       },
       {
         label: "Scenari di contribuzione",
         summary:
           "Confronta scenari ottimistici/pessimistici di rendimento e valuta l’adeguatezza delle posizioni individuali.",
-        href: "/casi/previdenza.html#proiezioni-sintetiche",
+        href: "/casi/previdenza#proiezioni-sintetiche",
       },
       {
         label: "Comunicazioni agli aderenti",
         summary:
           "Prepara una relazione periodica con KPI ESG, indicatori di adeguatezza e raccomandazioni personalizzate.",
-        href: "/casi/previdenza.html",
+        href: "/casi/previdenza",
       },
     ],
   },
@@ -83,7 +83,7 @@ export const APPLICATION_AREAS = [
         label: "ORSA semplificato",
         summary:
           "Costruisci una vista integrata di capitale disponibile/requisito e definisci trigger di escalation per il comitato rischi.",
-        href: "/casi/finanza-risk.html",
+        href: "/casi/finanza-risk",
       },
       {
         label: "VaR & TVaR multi-linea",
@@ -95,7 +95,7 @@ export const APPLICATION_AREAS = [
         label: "Gestione rischio climatico",
         summary:
           "Integra scenari NGFS e definisci KPI climatici da monitorare nel reporting periodico.",
-        href: "/casi/finanza-risk.html#kpi-da-monitorare",
+        href: "/casi/finanza-risk#kpi-da-monitorare",
       },
     ],
   },
@@ -108,19 +108,19 @@ export const APPLICATION_AREAS = [
         label: "Pipeline ETL & feature store",
         summary:
           "Implementa ingestion giornaliera con Airflow e gestisci la disponibilità delle feature con Feast.",
-        href: "/casi/data-science.html",
+        href: "/casi/data-science",
       },
       {
         label: "Monitoraggio drift modelli",
         summary:
           "Configura dashboard Evidently AI per analizzare il drift delle predizioni e aggiornare i modelli.",
-        href: "/casi/data-science.html#componenti-principali",
+        href: "/casi/data-science#componenti-principali",
       },
       {
         label: "Registro modelli EIOPA compliant",
         summary:
           "Documenta versioni, metriche e processi di governance per soddisfare le linee guida europee.",
-        href: "/casi/data-science.html",
+        href: "/casi/data-science",
       },
     ],
   },
@@ -133,19 +133,19 @@ export const APPLICATION_AREAS = [
         label: "Canvas value proposition",
         summary:
           "Compila il canvas per definire proposta di valore, segmenti di clientela e metriche di successo.",
-        href: "/casi/insurtech.html",
+        href: "/casi/insurtech",
       },
       {
         label: "Metriche MVP & sandbox",
         summary:
           "Stabilisci metriche di adozione e retention per sperimentazioni in sandbox regolamentare.",
-        href: "/casi/insurtech.html#backlog-mvp",
+        href: "/casi/insurtech#backlog-mvp",
       },
       {
         label: "Valutazione partner tecnologici",
         summary:
           "Verifica requisiti di sicurezza, SLA e compliance privacy dei fornitori InsurTech.",
-        href: "/casi/insurtech.html",
+        href: "/casi/insurtech",
       },
     ],
   },

--- a/content/pages/casi.js
+++ b/content/pages/casi.js
@@ -1,0 +1,68 @@
+export const CASE_STUDIES = [
+  {
+    slug: "assicurazioni-vita",
+    title: "Assicurazioni vita",
+    summary:
+      "Pricing, riserve e comunicazione regolamentare per prodotti caso morte, caso vita e partecipazioni agli utili.",
+    highlights: [
+      "Template per premi puri e analisi sensitività tassi",
+      "Linee guida IDD/POG per la documentazione",
+      "Suggerimenti per deliverable verso attuari incaricati e funzioni finance",
+    ],
+  },
+  {
+    slug: "assicurazioni-danni",
+    title: "Assicurazioni danni e salute",
+    summary:
+      "Segmentazione portafogli, stress test catastrofali e uso di variabili telematiche in ottica data-driven.",
+    highlights: [
+      "Workflow frequenza × severità in R",
+      "Check-list per stress e riassicurazione",
+      "Spunti per pricing dinamico e governance dei dati",
+    ],
+  },
+  {
+    slug: "previdenza",
+    title: "Previdenza complementare",
+    summary:
+      "Valutazioni IAS 19, scenari di contribuzione e comunicazioni agli aderenti di fondi pensione e casse.",
+    highlights: [
+      "Dataset sintetici per passività attuariali",
+      "Proiezioni scenari rendimento/costo",
+      "Indicatori ESG e di adeguatezza per i report",
+    ],
+  },
+  {
+    slug: "finanza-risk",
+    title: "Finanza e risk management",
+    summary:
+      "ORSA, misurazione del capitale economico e integrazione del rischio climatico nei framework di governance.",
+    highlights: [
+      "Template ORSA semplificato",
+      "Calcolo VaR/TVaR multi-linea",
+      "KPI climatici per reporting periodico",
+    ],
+  },
+  {
+    slug: "data-science",
+    title: "Data science attuariale",
+    summary:
+      "Automazione dei processi, MLOps e monitoraggio modelli per team attuariali e di advanced analytics.",
+    highlights: [
+      "Pipeline ETL con Airflow",
+      "Monitoraggio drift con Evidently",
+      "Requisiti di governance per registri modello",
+    ],
+  },
+  {
+    slug: "insurtech",
+    title: "Innovazione prodotti e InsurTech",
+    summary:
+      "Canvas strategici, backlog MVP e valutazione partner tecnologici per soluzioni parametriche e on-demand.",
+    highlights: [
+      "Modelli di discovery prodotto",
+      "Metriche di adozione e retention",
+      "Questionari vendor assessment",
+    ],
+  },
+];

--- a/content/pages/home.js
+++ b/content/pages/home.js
@@ -11,7 +11,7 @@ export const HOME_HIGHLIGHTS = [
   },
   {
     title: "Applicazioni pratiche",
-    text: "Dalla tariffazione vita e danni alla gestione delle riserve: workflow replicabili, dataset commentati e suggerimenti per presentare i risultati al management.",
+    text: "Dalla tariffazione vita e danni alla gestione delle riserve: workflow replicabili, case study guidati con dataset commentati e suggerimenti per presentare i risultati al management.",
     link: "/applicazioni",
   },
   {
@@ -70,6 +70,7 @@ export const HOME_PERSONAS = [
 ];
 
 export const HOME_UPDATES = [
+  "Nuova sezione Case study operativi con collegamenti diretti a applicazioni, strumenti e deliverable scaricabili.",
   "Nuove schede su IFRS 17, interazione con Solvency II e impatti contabili nella sezione Notizie.",
   "Script Python e R per simulare tavole di mortalità generazionali e scenari climatico-finanziari nella sezione Strumenti.",
   "Serie “Attuario nel mondo reale”: focus su ruoli in previdenza complementare, InsurTech e consulenza quantitativa.",

--- a/pages/applicazioni.js
+++ b/pages/applicazioni.js
@@ -49,6 +49,14 @@ export default function Applicazioni() {
           <li>Template di presentazione per raccontare i risultati a management e regulator.</li>
         </ul>
         <p className="small-print">Uso consentito esclusivamente a fini didattici e di studio.</p>
+        <div className="cta-row">
+          <Link className="button" href="/casi">
+            Esplora i case study operativi
+          </Link>
+          <Link className="button secondary" href="/strumenti">
+            Apri i calcolatori
+          </Link>
+        </div>
       </section>
 
       <style jsx>{`
@@ -85,6 +93,13 @@ export default function Applicazioni() {
         .application-card a {
           color: var(--link-color, #1d4ed8);
           font-weight: 600;
+        }
+
+        .cta-row {
+          margin-top: 24px;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 12px;
         }
       `}</style>
     </Layout>

--- a/pages/casi/assicurazioni-danni.js
+++ b/pages/casi/assicurazioni-danni.js
@@ -1,0 +1,146 @@
+import Link from "next/link";
+
+import Layout from "../../components/Layout";
+import CaseNavigation from "../../components/casi/CaseNavigation";
+
+const RELATED_CASES = ["data-science", "finanza-risk", "insurtech"];
+
+const RESOURCES = [
+  {
+    label: "Dataset sinistri auto anonimizzati",
+    href: "https://github.com/attuario-eu/dataset/tree/main/sinistri-auto",
+    description:
+      "Base dati sintetica con variabili frequenza/severità, esposizioni e indicatori telematici per esercitarsi con GLM.",
+  },
+  {
+    label: "Script GLM in R",
+    href: "https://github.com/attuario-eu/notebook/blob/main/glm-auto.Rmd",
+    description:
+      "Notebook RMarkdown con stima passo-passo, diagnostiche e grafici delle principali variabili esplicative.",
+  },
+  {
+    label: "Template stress test catastrofali",
+    href: "https://github.com/attuario-eu/templates/blob/main/stress-test-cat.xlsx",
+    description:
+      "Foglio di lavoro per applicare scenari vento e alluvione, con sezioni dedicate alla definizione della retention.",
+  },
+];
+
+const STEPS = [
+  {
+    title: "Data quality e feature engineering",
+    copy:
+      "Pulizia dei dati sinistri e costruzione di esposizioni coerenti con la periodicità dei premi; ingegnerizza variabili telematiche e indicatori di antifrode.",
+  },
+  {
+    title: "Modellazione frequenza × severità",
+    copy:
+      "Stima modelli GLM (Poisson/NegBin e Gamma/IG) e combina i risultati per ottenere il premio tecnico per segmento.",
+  },
+  {
+    title: "Stress catastrofali e riassicurazione",
+    copy:
+      "Applica scenari vento 1/100 sul portafoglio property, valuta la capacità riassicurativa e aggiorna il piano di ritenzione.",
+  },
+  {
+    title: "Pricing dinamico e governance",
+    copy:
+      "Definisci policy per l’uso di variabili telematiche, soglie di monitoraggio e criteri di fairness per tariffe personalizzate.",
+  },
+];
+
+const DELIVERABLES = [
+  {
+    label: "Report tecnico GLM",
+    detail:
+      "Documento con ipotesi, risultati dei modelli, confronti tra segmenti e implicazioni sui premi.",
+  },
+  {
+    label: "Matrice azioni riassicurative",
+    detail:
+      "Sintesi degli scenari catastrofali, livelli di perdita attesi e decisioni proposte per trattati quota-parte o stop-loss.",
+  },
+  {
+    label: "Linee guida pricing dinamico",
+    detail:
+      "Checklist con variabili autorizzate, metriche di monitoraggio e piano di revisione periodica con compliance e legal.",
+  },
+];
+
+const CONTROLS = [
+  "Assicurati che l’utilizzo di dati telematici rispetti GDPR e linee guida IVASS sulla protezione del consumatore.",
+  "Documenta i controlli di qualità sui dati e mantieni evidenza delle trasformazioni applicate.",
+  "Allinea il piano di monitoraggio con funzione risk management e anti-frode per escalation tempestive.",
+];
+
+export default function CaseAssicurazioniDanni() {
+  return (
+    <Layout
+      title="Case study · Assicurazioni danni"
+      eyebrow="Applicazioni attuariali"
+      intro="Percorso guidato per costruire tariffe auto/property data-driven, valutare scenari catastrofali e impostare un framework di pricing dinamico conforme."
+      metaDescription="Case study danni: dataset sinistri anonimizzati, script GLM, stress test catastrofali, deliverable e controlli di governance per pricing dinamico e riassicurazione."
+    >
+      <section className="info-panel">
+        <h2>Scenario di riferimento</h2>
+        <p>
+          Una compagnia danni vuole aggiornare la tariffa auto introducendo variabili telematiche e verificare la resilienza del piano riassicurativo a scenari vento. Il team deve produrre analisi GLM trasparenti, stress test documentati e linee guida per l’utilizzo dei dati.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="risorse-supporto">
+        <h2 id="risorse-supporto">Risorse di supporto</h2>
+        <ul className="list">
+          {RESOURCES.map(({ label, href, description }) => (
+            <li key={label}>
+              <a href={href} target="_blank" rel="noopener noreferrer">
+                {label}
+              </a>
+              <p>{description}</p>
+            </li>
+          ))}
+          <li>
+            <Link href="/calcolatori/portafoglio-variabile">Calcolatore portafoglio variabile</Link>
+            <p>
+              Stima VaR e TVaR multi-linea per misurare il capitale economico dopo gli stress catastrofali.
+            </p>
+          </li>
+        </ul>
+      </section>
+
+      <section className="section" aria-labelledby="workflow-operativo">
+        <h2 id="workflow-operativo">Workflow operativo</h2>
+        <div className="card-grid">
+          {STEPS.map(({ title, copy }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p>{copy}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" id="output-attesi" aria-labelledby="output-attesi-heading">
+        <h2 id="output-attesi-heading">Output attesi</h2>
+        <ul className="list">
+          {DELIVERABLES.map(({ label, detail }) => (
+            <li key={label}>
+              <strong>{label}.</strong> {detail}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="section" aria-labelledby="controlli-governance">
+        <h2 id="controlli-governance">Controlli di governance</h2>
+        <ul className="list">
+          {CONTROLS.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <CaseNavigation currentSlug="assicurazioni-danni" relatedSlugs={RELATED_CASES} />
+    </Layout>
+  );
+}

--- a/pages/casi/assicurazioni-vita.js
+++ b/pages/casi/assicurazioni-vita.js
@@ -1,0 +1,158 @@
+import Link from "next/link";
+
+import Layout from "../../components/Layout";
+import CaseNavigation from "../../components/casi/CaseNavigation";
+
+const RELATED_CASES = ["finanza-risk", "previdenza", "data-science"];
+
+const DATASETS = [
+  {
+    label: "Tavole IPS55 e proiezioni generazionali",
+    href: "https://github.com/attuario-eu/dataset/tree/main/mortalita",
+    description:
+      "File CSV con basi demografiche annuali e generazionali per confrontare premi puri sotto ipotesi differenti.",
+  },
+  {
+    label: "Curva risk-free EIOPA",
+    href: "https://www.eiopa.europa.eu/tools-and-data/risk-free-interest-rate-term-structures_it",
+    description:
+      "Serie storica dei tassi privi di rischio da utilizzare per analisi di sensitività e scenari di stress.",
+  },
+  {
+    label: "Template partecipazioni agli utili",
+    href: "https://github.com/attuario-eu/templates/blob/main/partecipazioni-utili.xlsx",
+    description:
+      "Foglio di calcolo con formule per proiettare il rendimento retrocesso e le riserve matematiche.",
+  },
+];
+
+const STEPS = [
+  {
+    title: "Impostazione delle ipotesi",
+    copy:
+      "Documenta basi demografiche, tassi tecnici, spese di caricamento e politiche di retrocessione. Evidenzia differenze tra prodotto puro rischio e misto.",
+  },
+  {
+    title: "Calcolo premi e riserve",
+    copy:
+      "Utilizza il calcolatore dedicato per premi unici o periodici e integra l’analisi Duration/Convexity per valutare l’impatto dei movimenti di tasso.",
+  },
+  {
+    title: "Sensitività e scenari",
+    copy:
+      "Simula variazioni ±50 bps sulla curva risk-free e confronta i risultati con tavole generazionali per misurare la volatilità del premio puro.",
+  },
+  {
+    title: "Comunicazione regolamentare",
+    copy:
+      "Prepara una nota metodologica per attuario incaricato e funzioni di controllo descrivendo ipotesi, fonti dati e coerenza con IDD/POG.",
+  },
+];
+
+const DELIVERABLES = [
+  {
+    label: "Memorandum tecnico",
+    detail:
+      "Documento sintetico con razionali delle ipotesi, risultati numerici principali e commento sulle sensitività svolte.",
+  },
+  {
+    label: "Workbook premi e riserve",
+    detail:
+      "Foglio di calcolo con formule auditabili e scenari separati per basi IPS55 e generazionali.",
+  },
+  {
+    label: "Slide per stakeholder non tecnici",
+    detail:
+      "Presentazione con grafici di sensitività, focus su impatti economici e timeline di implementazione.",
+  },
+];
+
+const COMPLIANCE = [
+  "Verifica la coerenza con linee guida IVASS n. 38/2018 e con i requisiti IDD sulla product oversight governance.",
+  "Aggiorna il fascicolo informativo recependo le modifiche di premio e riserva e condividi l’addendum con il marketing.",
+  "Conserva il tracciato dei dati utilizzati per audit interni e riesami dell’attuario incaricato.",
+];
+
+export default function CaseAssicurazioniVita() {
+  return (
+    <Layout
+      title="Case study · Assicurazioni vita"
+      eyebrow="Applicazioni attuariali"
+      intro="Esempio operativo per aggiornare premi, riserve e documentazione di un portafoglio temporanee caso morte con partecipazione agli utili."
+      metaDescription="Case study vita: dataset IPS55, workflow di calcolo premi e riserve, analisi di sensitività ai tassi e checklist IDD/POG da adattare alla propria compagnia."
+    >
+      <section className="info-panel">
+        <h2>Scenario di riferimento</h2>
+        <p>
+          Una compagnia vita intende aggiornare tariffe e nota tecnica di una temporanea caso morte a premio annuo. Il team attuariale deve confrontare basi IPS55 con proiezioni generazionali, verificare l’impatto dei movimenti di tasso e predisporre la documentazione IDD/POG.
+        </p>
+        <p className="small-print">
+          I numeri forniti sono dimostrativi: sostituiscili con le tue basi dati e valida ogni ipotesi con l’attuario incaricato.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="dataset-supporto">
+        <h2 id="dataset-supporto">Dataset e strumenti di supporto</h2>
+        <ul className="list">
+          {DATASETS.map(({ label, href, description }) => (
+            <li key={label}>
+              <a href={href} target="_blank" rel="noopener noreferrer">
+                {label}
+              </a>
+              <p>{description}</p>
+            </li>
+          ))}
+          <li>
+            <Link href="/calcolatori/premio-puro">Calcolatore premio puro</Link>
+            <p>
+              Imposta età, durata, tassi tecnici e spese per ottenere il premio puro di riferimento.
+            </p>
+          </li>
+          <li>
+            <Link href="/calcolatori/duration-convexity">Analisi Duration & Convexity</Link>
+            <p>
+              Valuta la sensibilità della riserva matematica a shock di tasso per supportare il comitato investimenti.
+            </p>
+          </li>
+        </ul>
+      </section>
+
+      <section className="section" aria-labelledby="workflow-operativo">
+        <h2 id="workflow-operativo">Workflow operativo</h2>
+        <div className="card-grid">
+          {STEPS.map(({ title, copy }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p>{copy}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" id="output-attesi" aria-labelledby="output-attesi-heading">
+        <h2 id="output-attesi-heading">Output attesi</h2>
+        <ul className="list">
+          {DELIVERABLES.map(({ label, detail }) => (
+            <li key={label}>
+              <strong>{label}.</strong> {detail}
+            </li>
+          ))}
+        </ul>
+        <p className="small-print">
+          Prevedi un check incrociato con attuario incaricato e funzione risk management prima di comunicare gli esiti esternamente.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="compliance-normativa">
+        <h2 id="compliance-normativa">Note di compliance</h2>
+        <ul className="list">
+          {COMPLIANCE.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <CaseNavigation currentSlug="assicurazioni-vita" relatedSlugs={RELATED_CASES} />
+    </Layout>
+  );
+}

--- a/pages/casi/data-science.js
+++ b/pages/casi/data-science.js
@@ -1,0 +1,156 @@
+import Layout from "../../components/Layout";
+import CaseNavigation from "../../components/casi/CaseNavigation";
+
+const RELATED_CASES = ["assicurazioni-danni", "finanza-risk", "insurtech"];
+
+const RESOURCES = [
+  {
+    label: "Repository pipeline Airflow",
+    href: "https://github.com/attuario-eu/pipeline-airflow",
+    description:
+      "Esempio di DAG per ingestione giornaliera, validazione dati e popolamento feature store su infrastruttura cloud.",
+  },
+  {
+    label: "Template monitoraggio Evidently",
+    href: "https://github.com/attuario-eu/templates/blob/main/evidently-dashboard.ipynb",
+    description:
+      "Notebook per configurare report periodici di data e prediction drift con alert automatici.",
+  },
+  {
+    label: "Registro modelli attuariali",
+    href: "https://github.com/attuario-eu/templates/blob/main/model-registry.xlsx",
+    description:
+      "Schema di tracciamento versioni, metriche e validazioni per soddisfare requisiti EIOPA e audit interni.",
+  },
+];
+
+const PHASES = [
+  {
+    title: "Discovery & data ingestion",
+    detail:
+      "Censisci le fonti dati (core assicurativo, CRM, data lake), mappa i permessi e definisci KPI di qualità.",
+  },
+  {
+    title: "Feature store e versioning",
+    detail:
+      "Configura pipeline per trasformazioni riproducibili, gestisci cataloghi di feature condivise e versioni tramite Git/MLflow.",
+  },
+  {
+    title: "Deploy e monitoraggio",
+    detail:
+      "Implementa CI/CD per i modelli, definisci soglie di alert e integra dashboard Evidently o Grafana per il monitoraggio continuo.",
+  },
+];
+
+const COMPONENTS = [
+  {
+    name: "Ingestion",
+    description:
+      "Airflow o Prefect per orchestrare estrazioni giornaliere con controlli di completezza e deduplicazione.",
+  },
+  {
+    name: "Feature store",
+    description:
+      "Feast o Tecton per pubblicare feature approvate con metadata e controlli di accesso granulari.",
+  },
+  {
+    name: "Model serving",
+    description:
+      "Servizi containerizzati (FastAPI, SageMaker) con deployment blue/green o canary e log centralizzati.",
+  },
+  {
+    name: "Monitoraggio",
+    description:
+      "Evidently, Prometheus/Grafana o Datafold per drift, quality check e alerting integrato con incident management.",
+  },
+];
+
+const DELIVERABLES = [
+  {
+    label: "Runbook MLOps",
+    text:
+      "Documento operativo con checklist di deploy, gestione incidenti e ruoli coinvolti nelle escalation.",
+  },
+  {
+    label: "Dashboard drift",
+    text:
+      "Visualizzazione condivisa con indicatori di data/prediction drift, soglie e log delle azioni correttive.",
+  },
+  {
+    label: "Registro modelli",
+    text:
+      "Archivio centralizzato delle versioni con metriche, dataset di training e validazioni indipendenti.",
+  },
+];
+
+export default function CaseDataScience() {
+  return (
+    <Layout
+      title="Case study · Data science attuariale"
+      eyebrow="Applicazioni attuariali"
+      intro="Blueprint per industrializzare modelli attuariali con pipeline dati affidabili, MLOps e monitoraggio continuo del drift."
+      metaDescription="Case study data science attuariale: repository Airflow, template Evidently, model registry e deliverable per orchestrare pipeline, deploy e monitoraggio dei modelli."
+    >
+      <section className="info-panel">
+        <h2>Scenario di riferimento</h2>
+        <p>
+          Un team attuariale vuole automatizzare il processo di pricing e reserving sfruttando pipeline dati e modelli machine learning. L’obiettivo è garantire riproducibilità, controllo delle versioni e monitoraggio costante di drift e performance.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="risorse-heading">
+        <h2 id="risorse-heading">Risorse di progetto</h2>
+        <ul className="list">
+          {RESOURCES.map(({ label, href, description }) => (
+            <li key={label}>
+              <a href={href} target="_blank" rel="noopener noreferrer">
+                {label}
+              </a>
+              <p>{description}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="section" aria-labelledby="fasi-heading">
+        <h2 id="fasi-heading">Fasi del percorso</h2>
+        <div className="card-grid">
+          {PHASES.map(({ title, detail }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p>{detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" id="componenti-principali" aria-labelledby="componenti-heading">
+        <h2 id="componenti-heading">Componenti principali</h2>
+        <div className="card-grid">
+          {COMPONENTS.map(({ name, description }) => (
+            <article key={name} className="card">
+              <h3>{name}</h3>
+              <p>{description}</p>
+            </article>
+          ))}
+        </div>
+        <p className="small-print">
+          Ogni componente deve avere owner chiari, log di esecuzione e controlli automatizzati documentati in modo da soddisfare audit e linee guida EIOPA.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="deliverable-heading">
+        <h2 id="deliverable-heading">Deliverable finali</h2>
+        <ul className="list">
+          {DELIVERABLES.map(({ label, text }) => (
+            <li key={label}>
+              <strong>{label}.</strong> {text}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <CaseNavigation currentSlug="data-science" relatedSlugs={RELATED_CASES} />
+    </Layout>
+  );
+}

--- a/pages/casi/finanza-risk.js
+++ b/pages/casi/finanza-risk.js
@@ -1,0 +1,166 @@
+import Link from "next/link";
+
+import Layout from "../../components/Layout";
+import CaseNavigation from "../../components/casi/CaseNavigation";
+
+const RELATED_CASES = ["assicurazioni-danni", "assicurazioni-vita", "previdenza"];
+
+const RESOURCES = [
+  {
+    label: "Template ORSA semplificato",
+    href: "https://github.com/attuario-eu/templates/blob/main/orsa-sintetico.xlsx",
+    description:
+      "Foglio di calcolo con sezioni per profilo di rischio, valutazione capitale e piano di azioni correttive.",
+  },
+  {
+    label: "Scenario NGFS climate",
+    href: "https://www.ngfs.net/ngfs-scenarios-portal/",
+    description:
+      "Portale ufficiale con dataset di scenari climatici utilizzabili per analizzare impatti su asset e passività.",
+  },
+  {
+    label: "Notebook simulazioni VaR/TVaR",
+    href: "https://github.com/attuario-eu/notebook/blob/main/var-tvar.ipynb",
+    description:
+      "Notebook Python per simulare distribuzioni di perdita multi-linea e confrontare metriche di capitale economico.",
+  },
+];
+
+const STEPS = [
+  {
+    title: "Raccolta input di rischio",
+    copy:
+      "Mappa rischi assicurativi, di mercato, di credito e operativi; consolida dati storici e scenari prospettici dal risk register aziendale.",
+  },
+  {
+    title: "Valutazione capitale economico",
+    copy:
+      "Esegui simulazioni Monte Carlo/analitiche utilizzando il calcolatore Portafoglio variabile e confronta i risultati con SCR/ORSA.",
+  },
+  {
+    title: "Analisi scenari climatici",
+    copy:
+      "Integra i dataset NGFS per valutare l’effetto su asset allocation, sinistri catastrofali e metriche di liquidità.",
+  },
+  {
+    title: "Piano di intervento",
+    copy:
+      "Definisci trigger quantitativi e qualitativi, responsabilità operative e tempistiche di attuazione in caso di superamento soglie.",
+  },
+];
+
+const ACTIONS = [
+  {
+    label: "Report ORSA sintetico",
+    detail:
+      "Documento di massimo 15 pagine con sintesi dei rischi materiali, risultati quantitativi e piano di intervento approvato dal board.",
+  },
+  {
+    label: "Dashboard capitale economico",
+    detail:
+      "Visualizzazione interattiva con serie storiche di capitale disponibile/requisito e breakdown per rischio.",
+  },
+  {
+    label: "Matrice responsabilità",
+    detail:
+      "RACI chart con azioni correttive, owner e tempistiche di revisione.",
+  },
+];
+
+const KPI = [
+  {
+    name: "Copertura capitale",
+    description:
+      "Rapporto tra capitale disponibile e requisito; monitora soglie early warning e target board.",
+  },
+  {
+    name: "Liquidity Coverage Ratio attuariale",
+    description:
+      "Valuta la capacità di fronteggiare deflussi inattesi considerando riserve tecniche e disponibilità liquide.",
+  },
+  {
+    name: "Exposure a rischio climatico",
+    description:
+      "Quota di portafoglio esposta a settori ad alta intensità carbonica o eventi fisici ricorrenti.",
+  },
+  {
+    name: "Sensitivity Solvency II",
+    description:
+      "Impatti percentuali di shock standard (tassi, spread, mortalità) sul capitale di solvibilità richiesto.",
+  },
+];
+
+export default function CaseFinanzaRisk() {
+  return (
+    <Layout
+      title="Case study · Finanza e risk management"
+      eyebrow="Applicazioni attuariali"
+      intro="Percorso per costruire un ORSA sintetico, stimare il capitale economico e integrare indicatori climatici nel framework di monitoraggio."
+      metaDescription="Case study risk management: template ORSA, simulazioni VaR/TVaR, scenari climatici NGFS, deliverable e KPI da monitorare per board e funzioni di controllo."
+    >
+      <section className="info-panel">
+        <h2>Scenario di riferimento</h2>
+        <p>
+          Un gruppo assicurativo vuole aggiornare la valutazione di rischio integrato in vista della riunione annuale del board. L’obiettivo è presentare un ORSA condensato con analisi di capitale economico, scenari climatici e un piano di intervento tracciabile.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="risorse-heading">
+        <h2 id="risorse-heading">Risorse utili</h2>
+        <ul className="list">
+          {RESOURCES.map(({ label, href, description }) => (
+            <li key={label}>
+              <a href={href} target="_blank" rel="noopener noreferrer">
+                {label}
+              </a>
+              <p>{description}</p>
+            </li>
+          ))}
+          <li>
+            <Link href="/calcolatori/portafoglio-variabile">Calcolatore portafoglio variabile</Link>
+            <p>
+              Stima VaR e TVaR per confrontare capitale economico e soglie di risk appetite definite nel RAF.
+            </p>
+          </li>
+        </ul>
+      </section>
+
+      <section className="section" aria-labelledby="workflow-heading">
+        <h2 id="workflow-heading">Workflow operativo</h2>
+        <div className="card-grid">
+          {STEPS.map(({ title, copy }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p>{copy}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" aria-labelledby="azioni-heading">
+        <h2 id="azioni-heading">Deliverable chiave</h2>
+        <ul className="list">
+          {ACTIONS.map(({ label, detail }) => (
+            <li key={label}>
+              <strong>{label}.</strong> {detail}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="section" id="kpi-da-monitorare" aria-labelledby="kpi-heading">
+        <h2 id="kpi-heading">KPI da monitorare</h2>
+        <div className="card-grid">
+          {KPI.map(({ name, description }) => (
+            <article key={name} className="card">
+              <h3>{name}</h3>
+              <p>{description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <CaseNavigation currentSlug="finanza-risk" relatedSlugs={RELATED_CASES} />
+    </Layout>
+  );
+}

--- a/pages/casi/index.js
+++ b/pages/casi/index.js
@@ -1,0 +1,73 @@
+import Link from "next/link";
+
+import Layout from "../../components/Layout";
+import { CASE_STUDIES } from "../../content/pages/casi";
+
+export default function Casi() {
+  return (
+    <Layout
+      title="Case study operativi"
+      eyebrow="Esempi guidati"
+      intro="Una raccolta di percorsi pratici per applicare la teoria attuariale. Ogni case study include dataset di supporto, note metodologiche e deliverable pronti per essere adattati al proprio contesto."
+      metaDescription="Elenco di case study attuariali con dataset, workflow e checklist normative su vita, danni, previdenza, risk management, data science e InsurTech."
+    >
+      <section className="card-grid">
+        {CASE_STUDIES.map(({ slug, title, summary, highlights }) => (
+          <article key={slug} className="card">
+            <h2>{title}</h2>
+            <p>{summary}</p>
+            <ul className="list">
+              {highlights.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+            <Link className="button secondary" href={`/casi/${slug}`}>
+              Apri il case study
+            </Link>
+          </article>
+        ))}
+      </section>
+
+      <section className="section info-panel">
+        <h2>Come usare i materiali</h2>
+        <p>
+          Ogni pagina include suggerimenti su dataset, strumenti digitali e indicatori da comunicare a stakeholder tecnici e non tecnici. Personalizza i template con i tuoi dati, cita sempre le fonti e tieni conto dei vincoli normativi del tuo settore.
+        </p>
+        <p className="small-print">
+          I contenuti sono pensati per studio e divulgazione: non costituiscono consulenza professionale né sostituiscono il giudizio di un attuario abilitato.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="supporto-operativo">
+        <h2 id="supporto-operativo">Collega teoria, strumenti e case reali</h2>
+        <p>
+          Ogni percorso è pensato per integrarsi con le sezioni <Link href="/applicazioni">Applicazioni</Link> e
+          <Link href="/strumenti"> Strumenti</Link>: parti dalle checklist, apri i calcolatori dedicati e combina i dataset
+          per creare deliverable coerenti con le normative vigenti.
+        </p>
+        <ul className="list">
+          <li>Imposta le ipotesi di lavoro con le guide sintetiche della sezione Applicazioni.</li>
+          <li>Esegui i calcoli con i tool online o i notebook open source suggeriti.</li>
+          <li>Adatta i template di comunicazione per stakeholder tecnici, management e regulator.</li>
+        </ul>
+        <div className="cta-row">
+          <Link className="button" href="/applicazioni">
+            Vai alle Applicazioni
+          </Link>
+          <Link className="button secondary" href="/strumenti">
+            Apri gli Strumenti
+          </Link>
+        </div>
+      </section>
+
+      <style jsx>{`
+        .cta-row {
+          margin-top: 24px;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 12px;
+        }
+      `}</style>
+    </Layout>
+  );
+}

--- a/pages/casi/insurtech.js
+++ b/pages/casi/insurtech.js
@@ -1,0 +1,144 @@
+import Link from "next/link";
+
+import Layout from "../../components/Layout";
+import CaseNavigation from "../../components/casi/CaseNavigation";
+
+const RELATED_CASES = ["assicurazioni-danni", "data-science", "assicurazioni-vita"];
+
+const ASSETS = [
+  {
+    label: "Canvas value proposition",
+    href: "https://github.com/attuario-eu/templates/blob/main/canvas-insurtech.pdf",
+    description:
+      "Modello compilabile per definire segmenti di clientela, problemi da risolvere, metriche di successo e canali.",
+  },
+  {
+    label: "Backlog MVP parametrici",
+    href: "https://github.com/attuario-eu/templates/blob/main/backlog-mvp.xlsx",
+    description:
+      "Foglio di calcolo con epiche, user story e criteri di accettazione per prototipi di polizze parametriche.",
+  },
+  {
+    label: "Questionario vendor assessment",
+    href: "https://github.com/attuario-eu/templates/blob/main/vendor-assessment.docx",
+    description:
+      "Checklist per valutare fornitori tecnologici su sicurezza, SLA, compliance e capacità di integrazione.",
+  },
+];
+
+const STREAMS = [
+  {
+    title: "Ricerca cliente e mercato",
+    body:
+      "Interviste qualitative, analisi concorrenti e studio delle normative per individuare pain point reali e vincoli regolamentari.",
+  },
+  {
+    title: "Prototipazione e test",
+    body:
+      "Sviluppo rapido di mock-up, calcolo del premio parametrico e simulazione dell’onboarding con stakeholder pilota.",
+  },
+  {
+    title: "Go-to-market e partnership",
+    body:
+      "Definizione di pricing, canali distributivi, accordi con provider dati e pianificazione campagne di lancio.",
+  },
+];
+
+const MVP_ITEMS = [
+  {
+    label: "Story map MVP",
+    detail:
+      "Sequenza di funzionalità must-have, should-have e nice-to-have per rilasciare un prototipo usabile in 6 settimane.",
+  },
+  {
+    label: "Piano test sandbox",
+    detail:
+      "Elenco di casi limite, metriche di monitoraggio e documentazione necessaria per l’accesso alla sandbox regolamentare.",
+  },
+  {
+    label: "Roadmap integrazione",
+    detail:
+      "Timeline di integrazione con sistemi core (policy administration, sinistri, billing) e milestone di sicurezza.",
+  },
+];
+
+const PARTNER_CHECKS = [
+  "Verifica requisiti di sicurezza (ISO 27001, penetration test recenti) e politiche di business continuity.",
+  "Analizza la compatibilità delle API con l’architettura esistente e i vincoli di latency.",
+  "Assicurati che il vendor consenta audit, export dei dati e processi di off-boarding documentati.",
+];
+
+export default function CaseInsurtech() {
+  return (
+    <Layout
+      title="Case study · Innovazione InsurTech"
+      eyebrow="Applicazioni attuariali"
+      intro="Framework per progettare un prodotto assicurativo parametrico, strutturare il backlog MVP e valutare partner tecnologici in ottica di governance."
+      metaDescription="Case study InsurTech: canvas value proposition, backlog MVP, checklist vendor e link al toolkit per orchestrare discovery, test in sandbox e partnership tecnologiche."
+    >
+      <section className="info-panel">
+        <h2>Scenario di riferimento</h2>
+        <p>
+          Una compagnia vuole lanciare un prodotto parametric travel legato a ritardi aerei. Il team cross-funzionale (attuari, product manager, IT, compliance) deve disegnare la value proposition, preparare test in sandbox regolamentare e selezionare partner dati affidabili.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="asset-heading">
+        <h2 id="asset-heading">Strumenti operativi</h2>
+        <ul className="list">
+          {ASSETS.map(({ label, href, description }) => (
+            <li key={label}>
+              <a href={href} target="_blank" rel="noopener noreferrer">
+                {label}
+              </a>
+              <p>{description}</p>
+            </li>
+          ))}
+          <li>
+            <Link href="/strumenti">Toolkit attuario.eu</Link>
+            <p>
+              Accedi a template aggiuntivi per business plan, metriche di prodotto e storytelling verso stakeholder.
+            </p>
+          </li>
+        </ul>
+      </section>
+
+      <section className="section" aria-labelledby="stream-heading">
+        <h2 id="stream-heading">Flussi di lavoro principali</h2>
+        <div className="card-grid">
+          {STREAMS.map(({ title, body }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p>{body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section info-panel" id="backlog-mvp" aria-labelledby="backlog-heading">
+        <h2 id="backlog-heading">Backlog MVP</h2>
+        <ul className="list">
+          {MVP_ITEMS.map(({ label, detail }) => (
+            <li key={label}>
+              <strong>{label}.</strong> {detail}
+            </li>
+          ))}
+        </ul>
+        <p className="small-print">
+          Assegna owner chiari a ogni epica, definisci dipendenze e aggiorna lo stato settimanalmente per mantenere allineati team e stakeholder.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="partner-heading">
+        <h2 id="partner-heading">Valutazione partner tecnologici</h2>
+        <ul className="list">
+          {PARTNER_CHECKS.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <CaseNavigation currentSlug="insurtech" relatedSlugs={RELATED_CASES} />
+    </Layout>
+  );
+}

--- a/pages/casi/previdenza.js
+++ b/pages/casi/previdenza.js
@@ -1,0 +1,168 @@
+import Link from "next/link";
+
+import Layout from "../../components/Layout";
+import CaseNavigation from "../../components/casi/CaseNavigation";
+
+const RELATED_CASES = ["assicurazioni-vita", "finanza-risk", "data-science"];
+
+const DATASETS = [
+  {
+    label: "Dataset IAS 19 sintetico",
+    href: "https://github.com/attuario-eu/dataset/tree/main/ias19",
+    description:
+      "Anagrafiche anonime con età, anzianità di servizio, retribuzioni e ipotesi economiche per calcolare l’obbligazione attuariale.",
+  },
+  {
+    label: "Serie storiche tasso inflazione e rendimento",
+    href: "https://www.bancaditalia.it/statistiche/tematiche/mercati-finanziari/",
+    description:
+      "Dati macroeconomici utili per calibrare scenari ottimistici, neutri e pessimistici di rendimento del fondo.",
+  },
+  {
+    label: "Template report aderenti",
+    href: "https://github.com/attuario-eu/templates/blob/main/report-aderenti.docx",
+    description:
+      "Modello di relazione periodica con KPI di adeguatezza, indicatori ESG e spazi per raccomandazioni personalizzate.",
+  },
+];
+
+const WORKFLOW = [
+  {
+    title: "Raccolta input",
+    copy:
+      "Verifica consistenza dei dati HR, definisci ipotesi demografiche (turnover, mortalità) e parametri economici (tasso di attualizzazione, inflazione).",
+  },
+  {
+    title: "Calcolo obbligazioni IAS 19",
+    copy:
+      "Utilizza il calcolatore dedicato per stimare DB0, Costo del servizio e sensitività alle ipotesi economiche chiave.",
+  },
+  {
+    title: "Scenari di contribuzione",
+    copy:
+      "Proietta la posizione individuale e collettiva con scenari di rendimento e volatilità diversi, stimando gap pensionistici.",
+  },
+  {
+    title: "Comunicazione agli aderenti",
+    copy:
+      "Trasforma i risultati in KPI comprensibili, accompagnati da note metodologiche e call to action sulle scelte di contribuzione.",
+  },
+];
+
+const DELIVERABLES = [
+  {
+    label: "Nota metodologica IAS 19",
+    detail:
+      "Documento con assunzioni, risultati numerici, sensitività e riconciliazione con i valori a bilancio.",
+  },
+  {
+    label: "Dashboard scenari contribuzione",
+    detail:
+      "Visualizzazione interattiva (Excel/BI) delle proiezioni ottimistiche, base e conservative con indicatori di adeguatezza.",
+  },
+  {
+    label: "Lettera agli aderenti",
+    detail:
+      "Comunicazione chiara con riepilogo delle performance, focus su sostenibilità ESG e suggerimenti personalizzati.",
+  },
+];
+
+const CHECKS = [
+  "Confronta le ipotesi con le ultime comunicazioni IVASS/COVIP e documenta eventuali scostamenti.",
+  "Coordina i messaggi con l’ufficio HR e la comunicazione interna per garantire coerenza con policy aziendali.",
+  "Archivia le basi dati in ambiente sicuro rispettando GDPR e policy di retention aziendale.",
+];
+
+export default function CasePrevidenza() {
+  return (
+    <Layout
+      title="Case study · Previdenza complementare"
+      eyebrow="Applicazioni attuariali"
+      intro="Guida operativa per valutare obbligazioni IAS 19, costruire scenari di contribuzione e predisporre la comunicazione verso aderenti e stakeholder interni."
+      metaDescription="Case study previdenza: dataset IAS 19, workflow di calcolo, scenari di contribuzione, proiezioni sintetiche e checklist di governance per fondi e casse."
+    >
+      <section className="info-panel">
+        <h2>Scenario di riferimento</h2>
+        <p>
+          Un’azienda vuole aggiornare la valutazione IAS 19 e fornire ai dipendenti un report personalizzato sulla posizione previdenziale. Il team attuariale deve integrare ipotesi economiche aggiornate, proiettare scenari di contribuzione e coordinare la comunicazione con HR e sostenibilità.
+        </p>
+      </section>
+
+      <section className="section" aria-labelledby="dataset-supporto">
+        <h2 id="dataset-supporto">Dataset e template</h2>
+        <ul className="list">
+          {DATASETS.map(({ label, href, description }) => (
+            <li key={label}>
+              <a href={href} target="_blank" rel="noopener noreferrer">
+                {label}
+              </a>
+              <p>{description}</p>
+            </li>
+          ))}
+          <li>
+            <Link href="/calcolatori/pensione-indicizzata">Calcolatore pensione indicizzata</Link>
+            <p>
+              Stima il montante atteso con rivalutazione annuale e confronta scenari di contribuzione.
+            </p>
+          </li>
+        </ul>
+      </section>
+
+      <section className="section" aria-labelledby="workflow-operativo">
+        <h2 id="workflow-operativo">Workflow operativo</h2>
+        <div className="card-grid">
+          {WORKFLOW.map(({ title, copy }) => (
+            <article key={title} className="card">
+              <h3>{title}</h3>
+              <p>{copy}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section
+        className="section info-panel"
+        id="proiezioni-sintetiche"
+        aria-labelledby="proiezioni-sintetiche-heading"
+      >
+        <h2 id="proiezioni-sintetiche-heading">Proiezioni sintetiche</h2>
+        <p>
+          Utilizza tre scenari di rendimento (ottimistico, base, pessimistico) e rappresenta gli intervalli di confidenza in modo intuitivo. Evidenzia l’effetto delle ipotesi di inflazione e delle rivalutazioni retributive sulla posizione finale.
+        </p>
+        <ul className="list">
+          <li>
+            <strong>Scenario ottimistico:</strong> rendimento medio annuo +150 bps rispetto al base, inflazione controllata.
+          </li>
+          <li>
+            <strong>Scenario base:</strong> parametri coerenti con curve risk-free EIOPA + spread coerente con la politica di investimento.
+          </li>
+          <li>
+            <strong>Scenario pessimistico:</strong> shock -200 bps nei primi tre anni, inflazione alta e aumento del turnover.
+          </li>
+        </ul>
+      </section>
+
+      <section className="section" aria-labelledby="output-attesi-heading">
+        <h2 id="output-attesi-heading">Deliverable finali</h2>
+        <ul className="list">
+          {DELIVERABLES.map(({ label, detail }) => (
+            <li key={label}>
+              <strong>{label}.</strong> {detail}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="section" aria-labelledby="controlli-heading">
+        <h2 id="controlli-heading">Controlli e governance</h2>
+        <ul className="list">
+          {CHECKS.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <CaseNavigation currentSlug="previdenza" relatedSlugs={RELATED_CASES} />
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- centralize the case study catalogue and expose it in the main navigation and home highlights
- add a reusable case navigation panel to every case page with related links and updated meta descriptions
- connect applicazioni and strumenti sections with dedicated calls to action and guidance from the case index

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68db33df10e0832d8fbee7e8fcafcc41