### PR TITLE
Add language filters to strumenti toolkit

### DIFF
--- a/content/pages/strumenti.js
+++ b/content/pages/strumenti.js
@@ -9,25 +9,28 @@ export const TOOL_RESOURCES = [
         summary:
           "Tabella con probabilità, importi e fattori di sconto per ricostruire il valore attuale atteso di rendite temporanee o vitalizie.",
         href: "/toolkit/valore-attuale.csv",
+        languages: [],
       },
       {
         label: "Dashboard sinistri pivot",
         summary:
           "Dataset di esempio per costruire tabelle pivot e grafici dinamici su premi, sinistri e combined ratio per ramo.",
         href: "/toolkit/dashboard-sinistri.csv",
+        languages: [],
       },
       {
         label: "Scheduler flussi ALM",
         summary:
           "Foglio con cash flow attivi/passivi e calcolo della differenza attualizzata utile per analisi di immunizzazione.",
         href: "/toolkit/alm-scheduler.csv",
+        languages: [],
       },
     ],
   },
   {
-    title: "R e Python",
+    title: "Toolkit R",
     description:
-      "Toolkit verificati per la modellazione attuariale in R e Python, con link a documentazione ufficiale, vignette e paper accademici citati.",
+      "Pacchetti, vignette e reference per pricing, riservazione e longevity modelling in R.",
     resources: [
       {
         label: "ChainLadder (R)",
@@ -35,6 +38,7 @@ export const TOOL_RESOURCES = [
           "Vignette ufficiali per il pacchetto leader nella riservazione sinistri: Chain Ladder deterministico, Mack e Bootstrap con esempi riproducibili.",
         href: "https://cran.r-project.org/web/packages/ChainLadder/vignettes/ChainLadder.html",
         external: true,
+        languages: ["R"],
       },
       {
         label: "insurancerating (R)",
@@ -42,6 +46,7 @@ export const TOOL_RESOURCES = [
           "Documentazione del pacchetto per il pricing con GLM, funzioni per l’esplorazione dati e tutorial su metriche di performance tariffaria.",
         href: "https://insurancerating.readthedocs.io/",
         external: true,
+        languages: ["R"],
       },
       {
         label: "actuar (R package)",
@@ -49,6 +54,7 @@ export const TOOL_RESOURCES = [
           "Codice sorgente e documentazione per tariffe collettive, distribuzioni attuariali e calcolo di premi di rischio e credibilità.",
         href: "https://github.com/boennecd/actuar",
         external: true,
+        languages: ["R"],
       },
       {
         label: "lifecontingencies (R package)",
@@ -56,6 +62,7 @@ export const TOOL_RESOURCES = [
           "Funzioni R per tavole di mortalità, valorizzazione di assicurazioni vita, rendite e misure di sensitività demografica.",
         href: "https://github.com/spedygiorgio/lifecontingencies",
         external: true,
+        languages: ["R"],
       },
       {
         label: "StMoMo (R package)",
@@ -63,13 +70,22 @@ export const TOOL_RESOURCES = [
           "Framework per modellare la mortalità con approcci Lee-Carter, Cairns-Blake-Dowd e varianti coortali per proiezioni LOB.",
         href: "https://github.com/amvillegas/StMoMo",
         external: true,
+        languages: ["R"],
       },
+    ],
+  },
+  {
+    title: "Toolkit Python",
+    description:
+      "Librerie e manuali per modellazione attuariale, riservazione e analisi di sopravvivenza in Python.",
+    resources: [
       {
         label: "chainladder-python",
         summary:
           "Manuale CAS per portare i metodi Chain Ladder in Python, completo di API reference e notebook su Mack, Bornhuetter-Ferguson e Bayesian reserving.",
         href: "https://chainladder-python.readthedocs.io/",
         external: true,
+        languages: ["Python"],
       },
       {
         label: "lifelines survival analysis",
@@ -77,6 +93,7 @@ export const TOOL_RESOURCES = [
           "Toolkit Python per l’analisi di sopravvivenza con Cox PH, Kaplan-Meier e strumenti per la calibrazione di tassi di decadenza.",
         href: "https://github.com/CamDavidsonPilon/lifelines",
         external: true,
+        languages: ["Python"],
       },
       {
         label: "lifelib – modelli vita open source",
@@ -84,6 +101,7 @@ export const TOOL_RESOURCES = [
           "Framework modulare per proiettare passività vita, calcolare BEL e CSM IFRS 17 con esempi in notebook Jupyter.",
         href: "https://github.com/lifelib-dev/lifelib",
         external: true,
+        languages: ["Python"],
       },
       {
         label: "GEMAct (Python)",
@@ -91,14 +109,136 @@ export const TOOL_RESOURCES = [
           "Libreria per modelli collettivi, copule e riserve stocastiche con tutorial su fitting, simulazione e valutazione della variabilità.",
         href: "https://gemact.readthedocs.io/",
         external: true,
+        languages: ["Python"],
       },
       {
         label: "PyMC & ArviZ actuarial workflows",
         summary:
           "Guida PyMC con esempi di regressioni Poisson, MCMC e diagnostica ArviZ per modellare frequenza e severità in chiave Bayesiana.",
         href: "https://www.pymc.io/projects/examples/en/latest/case_studies/insurance_claims.html",
-
         external: true,
+        languages: ["Python"],
+      },
+    ],
+  },
+  {
+    title: "Progettazione didattica",
+    description:
+      "Materiali per organizzare workshop, quiz e percorsi blended dedicati alla formazione attuariale.",
+    resources: [
+      {
+        label: "Checklist workshop attuariale",
+        summary: "Sequenza di attività e deliverable per condurre un laboratorio di 90 minuti con follow-up strutturato.",
+        href: "/toolkit/workshop-checklist.md",
+        languages: [],
+      },
+      {
+        label: "Guida quiz Moodle",
+        summary: "Documentazione su come creare question bank, randomizzare item e configurare feedback adattivi.",
+        href: "https://docs.moodle.org/402/it/Quiz",
+        external: true,
+        languages: [],
+      },
+      {
+        label: "Template rubrica valutazione",
+        summary: "Foglio di lavoro per assegnare punteggi a progetti didattici con criteri qualitativi e quantitativi.",
+        href: "https://www.credential.net/resources/assessment-rubric-template",
+        external: true,
+        languages: [],
+      },
+    ],
+  },
+  {
+    title: "Workflow e script R",
+    description:
+      "Notebook e script per experience studies, ESG e demo interattive costruiti con l’ecosistema R.",
+    resources: [
+      {
+        label: "actxps experience studies",
+        summary:
+          "Script R per costruire pipeline di experience study vita con estrazione dati, calcolo di tassi osservati/attesi e benchmark interattivi.",
+        href: "https://github.com/ActuarialVo/actxps",
+        external: true,
+        languages: ["R"],
+      },
+      {
+        label: "ESGtoolkit (R)",
+        summary:
+          "Notebook e funzioni per generare scenari stocastici multi-fattore, calibrati a curve risk-free e volatilità storiche.",
+        href: "https://github.com/fcasados/ESGtoolkit",
+        external: true,
+        languages: ["R"],
+      },
+      {
+        label: "StMoMo demo scripts",
+        summary:
+          "Esempi pratici per stimare modelli di mortalità, estrarre indicatori di longevità e produrre grafici di sensitività.",
+        href: "https://github.com/amvillegas/StMoMo/tree/master/vignettes",
+        external: true,
+        languages: ["R"],
+      },
+      {
+        label: "CAS Consumer Vehicle Toolkit",
+        summary:
+          "Repository CAS con workflow di pricing auto personale: esplorazione dati, fitting GLM e tecniche machine learning per tariffe competitive.",
+        href: "https://github.com/casact/consumer_vehicle_toolkit",
+        external: true,
+        languages: ["R"],
+      },
+      {
+        label: "experienceAnalytics (longevity studies)",
+        summary:
+          "Collezione di script R per analisi di esperienze vita: preparazione dati, credibilità Bayesiana e visualizzazioni interattive con flexdashboard.",
+        href: "https://github.com/ActuarialVol/experienceAnalytics",
+        external: true,
+        languages: ["R"],
+      },
+    ],
+  },
+  {
+    title: "Workflow e script Python",
+    description:
+      "Notebook e motori per simulazioni economiche, IFRS 17 e analisi demografiche in Python.",
+    resources: [
+      {
+        label: "pyesg – Economic Scenario Generator",
+        summary:
+          "Motore Python per simulare curve dei tassi, inflazione e rendimenti azionari con modelli stocastici standard (GBM, CIR, Vasicek).",
+        href: "https://github.com/jason-ash/pyesg",
+        external: true,
+        languages: ["Python"],
+      },
+      {
+        label: "IFRS17 Calculation Engine (Python)",
+        summary:
+          "Traduzione in Python del motore lifelib per calcolare cash flow attesi, CSM e analisi di sensibilità su portafogli assicurativi.",
+        href: "https://github.com/lifelib-dev/IFRS17CalculationEnginePython",
+        external: true,
+        languages: ["Python"],
+      },
+      {
+        label: "Life Expectancy Analysis notebook",
+        summary:
+          "Notebook su dataset OMS con pulizia dati, regressioni e visualizzazioni per individuare i driver della longevità.",
+        href: "https://github.com/aarohip28/Life-Expectancy-Analysis",
+        external: true,
+        languages: ["Python"],
+      },
+      {
+        label: "Systemorph IFRS17 Calculation Engine",
+        summary:
+          "Motore open source per valutazione IFRS 17 con moduli per calcolo cash flow, CSM e reporting, accompagnato da documentazione tecnica completa.",
+        href: "https://github.com/Systemorph/IFRS17CalculationEngine",
+        external: true,
+        languages: [],
+      },
+      {
+        label: "IFRS-17 PAA Implementation",
+        summary:
+          "Notebook e script per implementare passo-passo il Premium Allocation Approach, con esempi numerici commentati in lingua inglese e cinese.",
+        href: "https://github.com/YenLinWu/IFRS-17-PAA-Implementation",
+        external: true,
+        languages: ["Python"],
       },
     ],
   },
@@ -112,119 +252,21 @@ export const TOOL_RESOURCES = [
         summary: "Serie storiche demografiche internazionali per analisi di longevità e costruzione tavole generazionali.",
         href: "https://www.mortality.org",
         external: true,
+        languages: [],
       },
       {
         label: "CAS Loss Reserving Database",
         summary: "Dataset open source per esercitazioni su riserve danni, disponibilie in formato Excel e CSV.",
         href: "https://www.casact.org/data-management/database-queries/loss-reserving-database",
         external: true,
+        languages: [],
       },
       {
         label: "Eurostat – Insurance statistics",
         summary: "Indicatori su premi, sinistri e investimenti delle compagnie assicurative in Europa.",
         href: "https://ec.europa.eu/eurostat/web/insurance",
         external: true,
-      },
-    ],
-  },
-  {
-    title: "Progettazione didattica",
-    description:
-      "Materiali per organizzare workshop, quiz e percorsi blended dedicati alla formazione attuariale.",
-    resources: [
-      {
-        label: "Checklist workshop attuariale",
-        summary: "Sequenza di attività e deliverable per condurre un laboratorio di 90 minuti con follow-up strutturato.",
-        href: "/toolkit/workshop-checklist.md",
-      },
-      {
-        label: "Guida quiz Moodle",
-        summary: "Documentazione su come creare question bank, randomizzare item e configurare feedback adattivi.",
-        href: "https://docs.moodle.org/402/it/Quiz",
-        external: true,
-      },
-      {
-        label: "Template rubrica valutazione",
-        summary: "Foglio di lavoro per assegnare punteggi a progetti didattici con criteri qualitativi e quantitativi.",
-        href: "https://www.credential.net/resources/assessment-rubric-template",
-        external: true,
-      },
-    ],
-  },
-  {
-    title: "Script e notebook automation",
-    description:
-      "Script pronti per generare scenari economici, calcolare indicatori IFRS 17 e analizzare dati demografici con workflow ripetibili (uso didattico: validare sempre prima dell’impiego professionale).",
-    resources: [
-      {
-        label: "pyesg – Economic Scenario Generator",
-        summary:
-          "Motore Python per simulare curve dei tassi, inflazione e rendimenti azionari con modelli stocastici standard (GBM, CIR, Vasicek).",
-        href: "https://github.com/jason-ash/pyesg",
-        external: true,
-      },
-      {
-        label: "IFRS17 Calculation Engine (Python)",
-        summary:
-          "Traduzione in Python del motore lifelib per calcolare cash flow attesi, CSM e analisi di sensibilità su portafogli assicurativi.",
-        href: "https://github.com/lifelib-dev/IFRS17CalculationEnginePython",
-        external: true,
-      },
-      {
-        label: "Life Expectancy Analysis notebook",
-        summary:
-          "Notebook su dataset OMS con pulizia dati, regressioni e visualizzazioni per individuare i driver della longevità.",
-        href: "https://github.com/aarohip28/Life-Expectancy-Analysis",
-        external: true,
-      },
-      {
-        label: "actxps experience studies",
-        summary:
-          "Script R per costruire pipeline di experience study vita con estrazione dati, calcolo di tassi osservati/attesi e benchmark interattivi.",
-        href: "https://github.com/ActuarialVo/actxps",
-        external: true,
-      },
-      {
-        label: "ESGtoolkit (R)",
-        summary:
-          "Notebook e funzioni per generare scenari stocastici multi-fattore, calibrati a curve risk-free e volatilità storiche.",
-        href: "https://github.com/fcasados/ESGtoolkit",
-        external: true,
-      },
-      {
-        label: "StMoMo demo scripts",
-        summary:
-          "Esempi pratici per stimare modelli di mortalità, estrarre indicatori di longevità e produrre grafici di sensitività.",
-        href: "https://github.com/amvillegas/StMoMo/tree/master/vignettes",
-        external: true,
-      },
-      {
-        label: "Systemorph IFRS17 Calculation Engine",
-        summary:
-          "Motore open source per valutazione IFRS 17 con moduli per calcolo cash flow, CSM e reporting, accompagnato da documentazione tecnica completa.",
-        href: "https://github.com/Systemorph/IFRS17CalculationEngine",
-        external: true,
-      },
-      {
-        label: "IFRS-17 PAA Implementation",
-        summary:
-          "Notebook e script per implementare passo-passo il Premium Allocation Approach, con esempi numerici commentati in lingua inglese e cinese.",
-        href: "https://github.com/YenLinWu/IFRS-17-PAA-Implementation",
-        external: true,
-      },
-      {
-        label: "CAS Consumer Vehicle Toolkit",
-        summary:
-          "Repository CAS con workflow di pricing auto personale: esplorazione dati, fitting GLM e tecniche machine learning per tariffe competitive.",
-        href: "https://github.com/casact/consumer_vehicle_toolkit",
-        external: true,
-      },
-      {
-        label: "experienceAnalytics (longevity studies)",
-        summary:
-          "Collezione di script R per analisi di esperienze vita: preparazione dati, credibilità Bayesiana e visualizzazioni interattive con flexdashboard.",
-        href: "https://github.com/ActuarialVol/experienceAnalytics",
-        external: true,
+        languages: [],
       },
     ],
   },
@@ -239,6 +281,7 @@ export const TOOL_RESOURCES = [
           "Manuale gratuito dell’International Actuarial Association con esempi in R/Python su credibilità, frequenza-severità e gestione del rischio.",
         href: "https://openacttexts.github.io/Loss-Data-Analytics/",
         external: true,
+        languages: ["R", "Python"],
       },
       {
         label: "Statistical Foundations of Actuarial Learning",
@@ -246,6 +289,7 @@ export const TOOL_RESOURCES = [
           "Testo accademico con appendici computazionali su modelli predittivi, machine learning e validazione per assicurazioni danni.",
         href: "https://cfasociety.org/texas/Documents/Statistical%20Foundations%20of%20Actuarial%20Learning.pdf",
         external: true,
+        languages: [],
       },
       {
         label: "GitHub – progetti attuariali open",
@@ -253,6 +297,7 @@ export const TOOL_RESOURCES = [
           "Lista curata di repository attuariali (R, Python, Julia) per pricing, riservazione e longevity modelling con licenza open source.",
         href: "https://github.com/topics/actuarial-science",
         external: true,
+        languages: ["R", "Python"],
       },
     ],
   },

--- a/pages/strumenti.js
+++ b/pages/strumenti.js
@@ -1,26 +1,109 @@
 import Link from "next/link";
+import { useMemo, useState } from "react";
 
 import Layout from "../components/Layout";
 
 import { TOOL_RESOURCES } from "../content/pages/strumenti";
 
+const LANGUAGE_OPTIONS = ["R", "Python"];
+
 export default function Strumenti() {
+  const [selectedLanguages, setSelectedLanguages] = useState([]);
+
+  const filteredSections = useMemo(() => {
+    return TOOL_RESOURCES.map((section) => {
+      const matchingResources = section.resources.filter((resource) => {
+        if (selectedLanguages.length === 0) {
+          return true;
+        }
+
+        if (!resource.languages || resource.languages.length === 0) {
+          return false;
+        }
+
+        return resource.languages.some((language) =>
+          selectedLanguages.includes(language)
+        );
+      });
+
+      return { ...section, resources: matchingResources };
+    }).filter((section) => section.resources.length > 0);
+  }, [selectedLanguages]);
+
+  const hasResults = filteredSections.length > 0;
+
+  const toggleLanguage = (language) => {
+    setSelectedLanguages((current) => {
+      if (current.includes(language)) {
+        return current.filter((item) => item !== language);
+      }
+
+      return [...current, language];
+    });
+  };
+
   return (
     <Layout
       title="Strumenti & calcolatori"
       eyebrow="Toolkit operativo"
       intro="Tutorial, esempi di codice e risorse aperte per esercitarsi con modelli attuariali. Gli strumenti sono pensati a fini educativi e non sostituiscono attività professionale."
     >
+      <section className="filter-bar" aria-label="Filtra le risorse per linguaggio">
+        <fieldset>
+          <legend>Filtra per linguaggio</legend>
+          <div className="filter-options">
+            {LANGUAGE_OPTIONS.map((language) => {
+              const id = `language-${language.toLowerCase()}`;
+              const isChecked = selectedLanguages.includes(language);
+
+              return (
+                <label
+                  key={language}
+                  className={`filter-pill ${isChecked ? "is-active" : ""}`}
+                >
+                  <input
+                    id={id}
+                    type="checkbox"
+                    value={language}
+                    checked={isChecked}
+                    onChange={() => toggleLanguage(language)}
+                  />
+                  <span aria-hidden="true">{language}</span>
+                  <span className="sr-only">{`Filtra per ${language}`}</span>
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+      </section>
+
       <section className="card-grid">
-        {TOOL_RESOURCES.map(({ title, description, resources }) => (
+        {(selectedLanguages.length === 0 ? TOOL_RESOURCES : filteredSections).map(
+          ({ title, description, resources }) => (
           <article key={title} className="card toolkit-card">
             <h2>{title}</h2>
             <p>{description}</p>
             <ul className="list">
-              {resources.map(({ label, summary, href, external }) => (
+              {resources.map(({ label, summary, href, external, languages }) => (
                 <li key={label}>
                   <details>
-                    <summary>{label}</summary>
+                    <summary>
+                      <span className="summary-content">
+                        <span className="resource-label">{label}</span>
+                        {Array.isArray(languages) && languages.length > 0 && (
+                          <span className="language-badges">
+                            {languages.map((language) => (
+                              <span
+                                key={`${label}-${language}`}
+                                className="language-badge"
+                              >
+                                {language}
+                              </span>
+                            ))}
+                          </span>
+                        )}
+                      </span>
+                    </summary>
                     <p>{summary}</p>
                     {external ? (
                       <a href={href} target="_blank" rel="noopener noreferrer">
@@ -35,6 +118,11 @@ export default function Strumenti() {
             </ul>
           </article>
         ))}
+        {!hasResults && (
+          <p className="empty-state">
+            Nessuna risorsa corrisponde ai filtri selezionati. Prova a modificare le opzioni.
+          </p>
+        )}
       </section>
 
       <section className="section info-panel">
@@ -49,6 +137,96 @@ export default function Strumenti() {
       </section>
 
       <style jsx>{`
+        .filter-bar {
+          background: rgba(148, 163, 184, 0.18);
+          border-radius: 14px;
+          margin-bottom: 2rem;
+          padding: 1rem 1.25rem;
+        }
+
+        .filter-bar fieldset {
+          border: 0;
+          margin: 0;
+          padding: 0;
+        }
+
+        .filter-bar legend {
+          font-size: 1rem;
+          font-weight: 600;
+          margin-bottom: 0.75rem;
+        }
+
+        .filter-options {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.75rem;
+        }
+
+        .filter-pill {
+          align-items: center;
+          background: white;
+          border: 1px solid rgba(15, 23, 42, 0.15);
+          border-radius: 999px;
+          color: #0f172a;
+          cursor: pointer;
+          display: inline-flex;
+          font-weight: 600;
+          letter-spacing: 0.01em;
+          padding: 0.35rem 0.9rem;
+          position: relative;
+          transition: all 0.2s ease;
+        }
+
+        .filter-pill input {
+          appearance: none;
+          height: 100%;
+          left: 0;
+          margin: 0;
+          position: absolute;
+          top: 0;
+          width: 100%;
+        }
+
+        .filter-pill span:first-of-type {
+          pointer-events: none;
+        }
+
+        .filter-pill:is(:hover, :focus-within) {
+          border-color: rgba(37, 99, 235, 0.5);
+          box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.1);
+        }
+
+        .filter-pill.is-active {
+          background: #1d4ed8;
+          border-color: #1d4ed8;
+          color: white;
+          box-shadow: 0 0 0 4px rgba(29, 78, 216, 0.25);
+        }
+
+        .filter-pill input:focus-visible + span:first-of-type,
+        .filter-pill input:focus-visible ~ .sr-only {
+          outline: none;
+        }
+
+        .sr-only {
+          border: 0;
+          clip: rect(0 0 0 0);
+          height: 1px;
+          margin: -1px;
+          overflow: hidden;
+          padding: 0;
+          position: absolute;
+          width: 1px;
+        }
+
+        .empty-state {
+          color: #475569;
+          font-style: italic;
+          padding: 1.5rem 0;
+          text-align: center;
+          width: 100%;
+        }
+
         .toolkit-card details {
           background: rgba(148, 163, 184, 0.12);
           border-radius: 12px;
@@ -75,6 +253,38 @@ export default function Strumenti() {
           content: "−";
         }
 
+        .summary-content {
+          align-items: center;
+          display: flex;
+          gap: 0.75rem;
+          justify-content: space-between;
+        }
+
+        .resource-label {
+          flex: 1;
+          min-width: 0;
+        }
+
+        .language-badges {
+          display: inline-flex;
+          flex-wrap: wrap;
+          gap: 0.4rem;
+          justify-content: flex-end;
+        }
+
+        .language-badge {
+          background: rgba(37, 99, 235, 0.1);
+          border: 1px solid rgba(37, 99, 235, 0.25);
+          border-radius: 999px;
+          color: #1d4ed8;
+          font-size: 0.75rem;
+          font-weight: 600;
+          letter-spacing: 0.04em;
+          padding: 0.2rem 0.55rem;
+          text-transform: uppercase;
+          white-space: nowrap;
+        }
+
         .toolkit-card p {
           margin: 0.5rem 0 0.75rem;
         }
@@ -82,6 +292,18 @@ export default function Strumenti() {
         .toolkit-card a {
           color: var(--link-color, #1d4ed8);
           font-weight: 600;
+        }
+
+        @media (max-width: 640px) {
+          .summary-content {
+            align-items: flex-start;
+            flex-direction: column;
+            gap: 0.5rem;
+          }
+
+          .language-badges {
+            justify-content: flex-start;
+          }
         }
       `}</style>
     </Layout>


### PR DESCRIPTION
## Summary
- add language metadata to toolkit resources and reorganise sections by language
- introduce language filter controls with responsive badges and empty-state messaging on strumenti page
- style new filter pills and badges for accessibility across desktop and mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd31a76fc832d8570c41172b895a8